### PR TITLE
itemcache: add single-item cache

### DIFF
--- a/go.work
+++ b/go.work
@@ -6,6 +6,7 @@ use (
 	./cmd/monotag
 	./convert
 	./errs
+	./itemcache
 	./mapcache
 	./net
 	./pgconv

--- a/itemcache/go.mod
+++ b/itemcache/go.mod
@@ -1,0 +1,5 @@
+module github.com/omniaura/go-kit/itemcache
+
+go 1.25.5
+
+toolchain go1.26.1

--- a/itemcache/itemcache.go
+++ b/itemcache/itemcache.go
@@ -1,0 +1,165 @@
+package itemcache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// ItemCache caches a single value, refreshing it via an updater function
+// once the configured TTL has elapsed.
+type ItemCache[V any] struct {
+	item       Item[V]
+	set        bool
+	mu         sync.RWMutex
+	TTL        time.Duration
+	cleanupCtx context.Context
+}
+
+type Item[V any] struct {
+	V         V
+	UpdatedAt time.Time
+}
+
+type options struct {
+	TTL             *time.Duration
+	CleanupInterval *time.Duration
+	CleanupCtx      context.Context
+}
+
+type OptFunc func(*options) error
+
+func WithTTL(ttl time.Duration) OptFunc {
+	return func(o *options) error {
+		if ttl < 0 {
+			return fmt.Errorf("ttl less than 0: %d", ttl)
+		}
+		o.TTL = &ttl
+		return nil
+	}
+}
+
+func WithCleanup(ctx context.Context, interval time.Duration) OptFunc {
+	return func(o *options) error {
+		if interval < 0 {
+			return fmt.Errorf("interval less than 0: %d", interval)
+		}
+		o.CleanupCtx = ctx
+		o.CleanupInterval = &interval
+		return nil
+	}
+}
+
+func New[V any](opts ...OptFunc) (*ItemCache[V], error) {
+	var o options
+	for _, opt := range opts {
+		if err := opt(&o); err != nil {
+			return nil, err
+		}
+	}
+	var ic ItemCache[V]
+	if o.TTL != nil {
+		ic.TTL = *o.TTL
+	}
+	if o.CleanupInterval != nil {
+		if err := ic.cleanupRoutine(o.CleanupCtx, *o.CleanupInterval); err != nil {
+			return nil, err
+		}
+	}
+	return &ic, nil
+}
+
+func (ic *ItemCache[V]) cleanupRoutine(ctx context.Context, interval time.Duration) error {
+	if ic.TTL == 0 {
+		return errors.New("WithCleanup option is not valid for TTL 0 (value lives forever)")
+	}
+	if ic.TTL < 0 {
+		return errors.New("withCleanup option is not valid for TTL less than 0")
+	}
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+
+			case <-time.After(interval):
+				now := time.Now()
+				ic.mu.Lock()
+				if ic.set && now.Sub(ic.item.UpdatedAt) > ic.TTL {
+					ic.set = false
+					var zero Item[V]
+					ic.item = zero
+				}
+				ic.mu.Unlock()
+			}
+		}
+	}()
+	return nil
+}
+
+// Get returns the cached value, calling up to populate or refresh it when the
+// value is missing or has exceeded the TTL.
+func (ic *ItemCache[V]) Get(up func() (V, error), opts ...OptFunc) (V, error) {
+	var o options
+	for _, opt := range opts {
+		if err := opt(&o); err != nil {
+			var v V
+			return v, err
+		}
+	}
+
+	ic.mu.RLock()
+	item, ok := ic.item, ic.set
+	ic.mu.RUnlock()
+	now := time.Now()
+	if !ok {
+		return ic.update(up, now)
+	}
+	ttl := ic.TTL
+	if o.TTL != nil {
+		ttl = *o.TTL
+	}
+
+	if ttl == 0 {
+		return item.V, nil
+	}
+	age := now.Sub(item.UpdatedAt)
+	if age < ttl {
+		return item.V, nil
+	}
+	return ic.update(up, now)
+}
+
+func (ic *ItemCache[V]) update(up func() (V, error), now time.Time) (V, error) {
+	newVal, err := up()
+	if err != nil {
+		return newVal, err
+	}
+	ic.mu.Lock()
+	ic.item = Item[V]{
+		V:         newVal,
+		UpdatedAt: now,
+	}
+	ic.set = true
+	ic.mu.Unlock()
+	return newVal, nil
+}
+
+// Peek returns the currently cached item without triggering an update. The
+// boolean reports whether a value is currently cached.
+func (ic *ItemCache[V]) Peek() (Item[V], bool) {
+	ic.mu.RLock()
+	defer ic.mu.RUnlock()
+	return ic.item, ic.set
+}
+
+// Clear removes the cached value, forcing the next Get to call its updater.
+func (ic *ItemCache[V]) Clear() {
+	ic.mu.Lock()
+	defer ic.mu.Unlock()
+	var zero Item[V]
+	ic.item = zero
+	ic.set = false
+}

--- a/itemcache/itemcache_test.go
+++ b/itemcache/itemcache_test.go
@@ -1,0 +1,301 @@
+package itemcache_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/omniaura/go-kit/itemcache"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    []itemcache.OptFunc
+		wantErr bool
+	}{
+		{
+			name:    "default options",
+			opts:    nil,
+			wantErr: false,
+		},
+		{
+			name: "with valid TTL",
+			opts: []itemcache.OptFunc{
+				itemcache.WithTTL(time.Second),
+			},
+			wantErr: false,
+		},
+		{
+			name: "with invalid TTL",
+			opts: []itemcache.OptFunc{
+				itemcache.WithTTL(-1),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := itemcache.New[int](tt.opts...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestItemCache_Get(t *testing.T) {
+	t.Run("basic get and cache", func(t *testing.T) {
+		ic, err := itemcache.New[int]()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		calls := 0
+		updater := func() (int, error) {
+			calls++
+			return 42, nil
+		}
+
+		// First call should invoke updater
+		val, err := ic.Get(updater)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if val != 42 {
+			t.Errorf("expected 42, got %d", val)
+		}
+		if calls != 1 {
+			t.Errorf("expected 1 call, got %d", calls)
+		}
+
+		// Second call should use cached value
+		val, err = ic.Get(updater)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if val != 42 {
+			t.Errorf("expected 42, got %d", val)
+		}
+		if calls != 1 {
+			t.Errorf("expected 1 call, got %d", calls)
+		}
+	})
+
+	t.Run("with TTL", func(t *testing.T) {
+		ic, err := itemcache.New[int](itemcache.WithTTL(50 * time.Millisecond))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		calls := 0
+		updater := func() (int, error) {
+			calls++
+			return calls, nil
+		}
+
+		// First call
+		val, err := ic.Get(updater)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if val != 1 {
+			t.Errorf("expected 1, got %d", val)
+		}
+
+		// Wait for TTL to expire
+		time.Sleep(100 * time.Millisecond)
+
+		// Should get new value after TTL
+		val, err = ic.Get(updater)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if val != 2 {
+			t.Errorf("expected 2, got %d", val)
+		}
+		if calls != 2 {
+			t.Errorf("expected 2 calls, got %d", calls)
+		}
+	})
+
+	t.Run("per-call TTL override", func(t *testing.T) {
+		ic, err := itemcache.New[int]()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		calls := 0
+		updater := func() (int, error) {
+			calls++
+			return calls, nil
+		}
+
+		if _, err := ic.Get(updater); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(20 * time.Millisecond)
+
+		// TTL override forces a refresh since the value is older than 10ms.
+		val, err := ic.Get(updater, itemcache.WithTTL(10*time.Millisecond))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if val != 2 {
+			t.Errorf("expected 2, got %d", val)
+		}
+	})
+
+	t.Run("updater error", func(t *testing.T) {
+		ic, err := itemcache.New[int]()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expectedErr := errors.New("update failed")
+		updater := func() (int, error) {
+			return 0, expectedErr
+		}
+
+		_, err = ic.Get(updater)
+		if err != expectedErr {
+			t.Errorf("expected error %v, got %v", expectedErr, err)
+		}
+	})
+}
+
+// TestItemCache_Concurrent exercises the cache from many goroutines while a
+// cleanup routine runs, relying on the race detector (go test -race) to catch
+// unsynchronized access to the shared item.
+func TestItemCache_Concurrent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ic, err := itemcache.New[int](
+		itemcache.WithTTL(time.Millisecond),
+		itemcache.WithCleanup(ctx, time.Millisecond),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var calls atomic.Int64
+	updater := func() (int, error) {
+		return int(calls.Add(1)), nil
+	}
+
+	const goroutines = 50
+	const iterations = 200
+
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := range iterations {
+				switch (g + i) % 3 {
+				case 0:
+					if _, err := ic.Get(updater); err != nil {
+						t.Errorf("Get: %v", err)
+						return
+					}
+				case 1:
+					ic.Peek()
+				case 2:
+					ic.Clear()
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+}
+
+func TestItemCache_Cleanup(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ic, err := itemcache.New[int](
+		itemcache.WithTTL(100*time.Millisecond),
+		itemcache.WithCleanup(ctx, 100*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	updater := func() (int, error) {
+		return 42, nil
+	}
+
+	// Populate the cache
+	if _, err = ic.Get(updater); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for cleanup
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify item was cleaned up
+	if _, ok := ic.Peek(); ok {
+		t.Errorf("expected no cached item after cleanup")
+	}
+}
+
+func TestItemCache_Peek(t *testing.T) {
+	ic, err := itemcache.New[int]()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := ic.Peek(); ok {
+		t.Errorf("expected no cached item before any Get")
+	}
+
+	if _, err := ic.Get(func() (int, error) { return 7, nil }); err != nil {
+		t.Fatal(err)
+	}
+
+	item, ok := ic.Peek()
+	if !ok {
+		t.Fatal("expected a cached item after Get")
+	}
+	if item.V != 7 {
+		t.Errorf("expected 7, got %d", item.V)
+	}
+}
+
+func TestItemCache_Clear(t *testing.T) {
+	ic, err := itemcache.New[int]()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	calls := 0
+	updater := func() (int, error) {
+		calls++
+		return calls, nil
+	}
+
+	if _, err := ic.Get(updater); err != nil {
+		t.Fatal(err)
+	}
+	ic.Clear()
+	if _, ok := ic.Peek(); ok {
+		t.Errorf("expected no cached item after Clear")
+	}
+
+	// Next Get should re-invoke the updater.
+	val, err := ic.Get(updater)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val != 2 {
+		t.Errorf("expected 2, got %d", val)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 calls, got %d", calls)
+	}
+}

--- a/itemcache/itemcache_test.go
+++ b/itemcache/itemcache_test.go
@@ -1,7 +1,6 @@
 package itemcache_test
 
 import (
-	"context"
 	"errors"
 	"sync"
 	"sync/atomic"
@@ -172,8 +171,7 @@ func TestItemCache_Get(t *testing.T) {
 // cleanup routine runs, relying on the race detector (go test -race) to catch
 // unsynchronized access to the shared item.
 func TestItemCache_Concurrent(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	ic, err := itemcache.New[int](
 		itemcache.WithTTL(time.Millisecond),
@@ -215,8 +213,7 @@ func TestItemCache_Concurrent(t *testing.T) {
 }
 
 func TestItemCache_Cleanup(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	ic, err := itemcache.New[int](
 		itemcache.WithTTL(100*time.Millisecond),


### PR DESCRIPTION
## Summary
- Adds an `itemcache` package that caches a single value, mirroring the existing `mapcache` package which caches a map of values.
- Same options surface: `WithTTL` and `WithCleanup` (background eviction of the expired item).
- `Get(up, opts...)` populates/refreshes via an updater func, with optional per-call TTL override.
- Adds `Peek()` (read cached item without triggering an update) and `Clear()` helpers.
- Registered the new module in `go.work`.

## Concurrency safety
- All access to the shared item is guarded by a `sync.RWMutex`.
- `TestItemCache_Concurrent` hammers `Get`/`Peek`/`Clear` from 50 goroutines while the cleanup routine runs; the suite passes under `go test -race`.

## Test plan
- `cd itemcache && go vet ./... && go test -race -count=1 ./...` → passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ItemCache — a generic caching solution with configurable time-to-live (TTL) and optional background cleanup.
  * Supports per-call TTL overrides and operations to inspect or clear cached data.

* **Tests**
  * Added comprehensive test coverage for caching behavior, including concurrency, expiry, and cleanup scenarios.

* **Chores**
  * Updated Go module configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->