### PR TITLE
feat: add set constructor keys option

### DIFF
--- a/set/options.go
+++ b/set/options.go
@@ -2,6 +2,8 @@ package set
 
 type options struct {
 	capacity int
+	keysLen  int
+	addKeys  func(any)
 }
 
 type optFunc func(*options)
@@ -12,5 +14,18 @@ func WithCapacity(capacity int) optFunc {
 	}
 	return func(o *options) {
 		o.capacity = capacity
+	}
+}
+
+func WithKeys[T comparable](keys []T) optFunc {
+	return func(o *options) {
+		o.keysLen = len(keys)
+		o.addKeys = func(dst any) {
+			s, ok := dst.(Set[T])
+			if !ok {
+				panic("set: WithKeys key type does not match set type")
+			}
+			s.AddAll(keys...)
+		}
 	}
 }

--- a/set/set.go
+++ b/set/set.go
@@ -8,10 +8,17 @@ func New[T comparable](opts ...optFunc) Set[T] {
 	for _, opt := range opts {
 		opt(&o)
 	}
-	if o.capacity > 0 {
-		return make(Set[T], o.capacity)
+
+	capacity := o.capacity
+	if o.keysLen > capacity {
+		capacity = o.keysLen
 	}
-	return make(Set[T])
+
+	s := make(Set[T], capacity)
+	if o.addKeys != nil {
+		o.addKeys(s)
+	}
+	return s
 }
 
 // Add adds a key to the set.

--- a/set/set_test.go
+++ b/set/set_test.go
@@ -1,0 +1,47 @@
+package set_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/omniaura/go-kit/set"
+)
+
+func TestNewWithKeys(t *testing.T) {
+	s := set.New[string](set.WithKeys([]string{"b", "a", "b"}))
+
+	if got := len(s); got != 2 {
+		t.Fatalf("len(New(WithKeys())) = %d, want 2", got)
+	}
+	for _, key := range []string{"a", "b"} {
+		if !s.Contains(key) {
+			t.Fatalf("Contains(%q) = false, want true", key)
+		}
+	}
+}
+
+func TestNewWithKeysAndCapacity(t *testing.T) {
+	s := set.New[int](
+		set.WithCapacity(8),
+		set.WithKeys([]int{1, 2, 3}),
+	)
+
+	if got := len(s); got != 3 {
+		t.Fatalf("len(New(WithCapacity(), WithKeys())) = %d, want 3", got)
+	}
+	if !s.Contains(1) || !s.Contains(2) || !s.Contains(3) {
+		t.Fatalf("New(WithKeys()) did not seed all keys")
+	}
+}
+
+func TestNewSyncWithKeys(t *testing.T) {
+	s := set.NewSync[string](set.WithKeys([]string{"c", "a", "b"}))
+
+	got := s.Slice()
+	slices.Sort(got)
+	want := []string{"a", "b", "c"}
+
+	if !slices.Equal(got, want) {
+		t.Fatalf("Slice() = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- add set.WithKeys for seeding New from a slice of keys
- size the backing map to fit provided keys when larger than WithCapacity
- cover plain and sync constructors with tests

## Tests
- go test ./... (from set module)