### PR TITLE
feat(pgconv): add analyzer with suggested fixes

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -1,2 +1,7 @@
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
+golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
+golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa/go.mod h1:kHjTxDEnAu6/Nl9lDkzjWpR+bmKfxeiRuSDlsMb70gE=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/pgconv/cmd/pgconvlint/main.go
+++ b/pgconv/cmd/pgconvlint/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"github.com/omniaura/go-kit/pgconv/pgconvlint"
+	"golang.org/x/tools/go/analysis/singlechecker"
+)
+
+func main() {
+	singlechecker.Main(pgconvlint.Analyzer)
+}

--- a/pgconv/go.mod
+++ b/pgconv/go.mod
@@ -7,4 +7,10 @@ toolchain go1.26.1
 require (
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.9.1
+	golang.org/x/tools v0.44.0
+)
+
+require (
+	golang.org/x/mod v0.35.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
 )

--- a/pgconv/go.sum
+++ b/pgconv/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
@@ -14,9 +16,13 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
-golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
+golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/text v0.29.0 h1:1neNs90w9YzJ9BocxfsQNHKuAT4pkghyXc4nhZ6sJvk=
 golang.org/x/text v0.29.0/go.mod h1:7MhJOA9CD2qZyOKYazxdYMF85OwPdEr9jTtBpO7ydH4=
+golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
+golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pgconv/internal/lintignore/lintignore.go
+++ b/pgconv/internal/lintignore/lintignore.go
@@ -1,0 +1,106 @@
+// Package lintignore parses standard Go lint suppression comments.
+package lintignore
+
+import (
+	"go/ast"
+	"go/token"
+	"strings"
+)
+
+// Suppressions stores //lint:ignore and //lint:file-ignore directives for a file.
+type Suppressions struct {
+	fset *token.FileSet
+	line map[int]map[string]bool
+	file map[string]bool
+}
+
+// New parses lint suppression directives from file comments.
+func New(fset *token.FileSet, file *ast.File) Suppressions {
+	s := Suppressions{
+		fset: fset,
+		line: make(map[int]map[string]bool),
+		file: make(map[string]bool),
+	}
+
+	for _, group := range file.Comments {
+		for _, comment := range group.List {
+			kind, analyzers, ok := parseDirective(comment.Text)
+			if !ok {
+				continue
+			}
+
+			switch kind {
+			case "lint:ignore":
+				endLine := fset.PositionFor(comment.End(), false).Line
+				s.addLine(endLine+1, analyzers)
+			case "lint:file-ignore":
+				for _, analyzer := range analyzers {
+					s.file[analyzer] = true
+				}
+			}
+		}
+	}
+
+	return s
+}
+
+// Ignored reports whether analyzer diagnostics at pos should be suppressed.
+func (s Suppressions) Ignored(pos token.Pos, analyzer string) bool {
+	if matches(s.file, analyzer) {
+		return true
+	}
+
+	line := s.fset.PositionFor(pos, false).Line
+	return matches(s.line[line], analyzer)
+}
+
+func (s Suppressions) addLine(line int, analyzers []string) {
+	if line <= 0 {
+		return
+	}
+	if s.line[line] == nil {
+		s.line[line] = make(map[string]bool)
+	}
+	for _, analyzer := range analyzers {
+		s.line[line][analyzer] = true
+	}
+}
+
+func parseDirective(raw string) (string, []string, bool) {
+	text := strings.TrimSpace(commentText(raw))
+	fields := strings.Fields(text)
+	if len(fields) < 3 {
+		return "", nil, false
+	}
+
+	kind := fields[0]
+	if kind != "lint:ignore" && kind != "lint:file-ignore" {
+		return "", nil, false
+	}
+
+	var analyzers []string
+	for _, analyzer := range strings.Split(fields[1], ",") {
+		analyzer = strings.TrimSpace(analyzer)
+		if analyzer != "" {
+			analyzers = append(analyzers, analyzer)
+		}
+	}
+	return kind, analyzers, len(analyzers) > 0
+}
+
+func commentText(raw string) string {
+	switch {
+	case strings.HasPrefix(raw, "//"):
+		return strings.TrimSpace(strings.TrimPrefix(raw, "//"))
+	case strings.HasPrefix(raw, "/*") && strings.HasSuffix(raw, "*/"):
+		raw = strings.TrimPrefix(raw, "/*")
+		raw = strings.TrimSuffix(raw, "*/")
+		return strings.TrimSpace(raw)
+	default:
+		return strings.TrimSpace(raw)
+	}
+}
+
+func matches(analyzers map[string]bool, analyzer string) bool {
+	return analyzers[analyzer] || analyzers["all"] || analyzers["*"]
+}

--- a/pgconv/pgconvlint/analyzer.go
+++ b/pgconv/pgconvlint/analyzer.go
@@ -1,0 +1,1070 @@
+// Package pgconvlint reports manual pgtype conversions that should use pgconv.
+package pgconvlint
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/omniaura/go-kit/pgconv/internal/lintignore"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/ast/astutil"
+)
+
+const (
+	analyzerName = "pgconvlint"
+	pgtypePath   = "github.com/jackc/pgx/v5/pgtype"
+	pgencodePath = "github.com/omniaura/go-kit/pgconv/pgencode"
+	pgdecodePath = "github.com/omniaura/go-kit/pgconv/pgdecode"
+)
+
+// Analyzer checks for manual pgtype <-> regular Go value conversions.
+var Analyzer = &analysis.Analyzer{
+	Name: analyzerName,
+	Doc:  "check for manual pgtype conversions that should use pgencode or pgdecode; suppress with //lint:ignore pgconvlint <reason>",
+	URL:  "https://pkg.go.dev/github.com/omniaura/go-kit/pgconv/pgconvlint",
+	Run:  run,
+}
+
+type reporter struct {
+	pass    *analysis.Pass
+	file    *ast.File
+	ignores lintignore.Suppressions
+}
+
+type pgtypeRule struct {
+	valueFields  []string
+	encodeFunc   string
+	encodeMethod string
+	decodeFunc   string
+}
+
+type pgconvUse struct {
+	kind      string
+	qualifier string
+}
+
+type tinyWrapper struct {
+	name      string
+	kind      string
+	qualifier string
+	params    []string
+	expr      ast.Expr
+}
+
+type encodeReplacement struct {
+	text    string
+	display string
+}
+
+var pgtypeRules = map[string]pgtypeRule{
+	"Text": {
+		valueFields:  []string{"String"},
+		encodeFunc:   "String",
+		encodeMethod: "Text",
+		decodeFunc:   "Text",
+	},
+	"Bool": {
+		valueFields:  []string{"Bool"},
+		encodeFunc:   "Bool",
+		encodeMethod: "Bool",
+		decodeFunc:   "Bool",
+	},
+	"Int2": {
+		valueFields:  []string{"Int16"},
+		encodeFunc:   "Int16",
+		encodeMethod: "Int2",
+		decodeFunc:   "Int2",
+	},
+	"Int4": {
+		valueFields:  []string{"Int32"},
+		encodeFunc:   "Int32",
+		encodeMethod: "Int4",
+		decodeFunc:   "Int4",
+	},
+	"Int8": {
+		valueFields:  []string{"Int64"},
+		encodeFunc:   "Int64",
+		encodeMethod: "Int8",
+		decodeFunc:   "Int8",
+	},
+	"Float8": {
+		valueFields:  []string{"Float64"},
+		encodeFunc:   "Float64",
+		encodeMethod: "Float8",
+		decodeFunc:   "Float8",
+	},
+	"Date": {
+		valueFields:  []string{"Time"},
+		encodeFunc:   "Time",
+		encodeMethod: "Date",
+		decodeFunc:   "Date",
+	},
+	"Timestamp": {
+		valueFields:  []string{"Time"},
+		encodeFunc:   "Time",
+		encodeMethod: "Timestamp",
+		decodeFunc:   "Timestamp",
+	},
+	"Timestamptz": {
+		valueFields:  []string{"Time"},
+		encodeFunc:   "Time",
+		encodeMethod: "Timestamptz",
+		decodeFunc:   "Timestamptz",
+	},
+	"UUID": {
+		valueFields:  []string{"Bytes"},
+		encodeFunc:   "UUID",
+		encodeMethod: "UUID",
+		decodeFunc:   "UUID",
+	},
+}
+
+func run(pass *analysis.Pass) (any, error) {
+	if skipPackage(pass) {
+		return nil, nil
+	}
+
+	wrappers := collectTinyWrappers(pass)
+
+	for _, file := range pass.Files {
+		if skipFile(pass, file) {
+			continue
+		}
+
+		parents := parentMap(file)
+		reporter := reporter{
+			pass:    pass,
+			file:    file,
+			ignores: lintignore.New(pass.Fset, file),
+		}
+		ast.Inspect(file, func(node ast.Node) bool {
+			switch n := node.(type) {
+			case *ast.FuncDecl:
+				checkPgconvWrapper(pass, reporter, n)
+			case *ast.CompositeLit:
+				checkCompositeLiteral(pass, reporter, n)
+			case *ast.SelectorExpr:
+				checkSelector(pass, reporter, parents, n)
+			case *ast.CallExpr:
+				checkWrapperCall(pass, reporter, wrappers, n)
+			}
+			return true
+		})
+	}
+	return nil, nil
+}
+
+func skipPackage(pass *analysis.Pass) bool {
+	if pass.Pkg == nil {
+		return false
+	}
+	switch pass.Pkg.Path() {
+	case pgencodePath, pgdecodePath:
+		return true
+	default:
+		return false
+	}
+}
+
+func collectTinyWrappers(pass *analysis.Pass) map[*types.Func]tinyWrapper {
+	wrappers := make(map[*types.Func]tinyWrapper)
+	for _, file := range pass.Files {
+		if skipFile(pass, file) {
+			continue
+		}
+
+		ignores := lintignore.New(pass.Fset, file)
+		ast.Inspect(file, func(node ast.Node) bool {
+			decl, ok := node.(*ast.FuncDecl)
+			if !ok || decl.Name == nil || ignores.Ignored(decl.Name.Pos(), analyzerName) {
+				return true
+			}
+			wrapper, ok := tinyWrapperInfo(pass, decl)
+			if !ok || wrapper.expr == nil {
+				return true
+			}
+			fn, ok := pass.TypesInfo.Defs[decl.Name].(*types.Func)
+			if ok {
+				wrappers[fn] = wrapper
+			}
+			return true
+		})
+	}
+	return wrappers
+}
+
+func checkPgconvWrapper(pass *analysis.Pass, r reporter, decl *ast.FuncDecl) {
+	wrapper, ok := tinyWrapperInfo(pass, decl)
+	if !ok {
+		return
+	}
+
+	r.report(decl.Name.Pos(), decl.Name.End(), fmt.Sprintf("tiny %s wrapper %s; call %s directly at the use site", wrapper.kind, decl.Name.Name, wrapper.kind), nil)
+}
+
+func tinyWrapperInfo(pass *analysis.Pass, decl *ast.FuncDecl) (tinyWrapper, bool) {
+	if decl.Body == nil || decl.Name == nil || len(decl.Body.List) > 4 {
+		return tinyWrapper{}, false
+	}
+
+	params := paramNameList(decl.Type.Params)
+	paramSet := make(map[string]bool, len(params))
+	for _, param := range params {
+		paramSet[param] = true
+	}
+	if len(paramSet) == 0 {
+		return tinyWrapper{}, false
+	}
+
+	wrapper := tinyWrapper{name: decl.Name.Name, params: params}
+	ast.Inspect(decl.Body, func(node ast.Node) bool {
+		if wrapper.kind != "" {
+			return false
+		}
+		if _, ok := node.(*ast.FuncLit); ok {
+			return false
+		}
+		ret, ok := node.(*ast.ReturnStmt)
+		if !ok {
+			return true
+		}
+		for _, result := range ret.Results {
+			if use, ok := containsPgconvParamCall(pass, result, paramSet); ok {
+				wrapper.kind = use.kind
+				wrapper.qualifier = use.qualifier
+				return false
+			}
+		}
+		return true
+	})
+	if wrapper.kind == "" {
+		return tinyWrapper{}, false
+	}
+
+	if len(decl.Body.List) == 1 {
+		if ret, ok := decl.Body.List[0].(*ast.ReturnStmt); ok && len(ret.Results) == 1 {
+			if use, ok := containsPgconvParamCall(pass, ret.Results[0], paramSet); ok {
+				wrapper.kind = use.kind
+				wrapper.qualifier = use.qualifier
+				wrapper.expr = ret.Results[0]
+			}
+		}
+	}
+
+	return wrapper, true
+}
+
+func skipFile(pass *analysis.Pass, file *ast.File) bool {
+	if ast.IsGenerated(file) {
+		return true
+	}
+
+	tf := pass.Fset.File(file.Pos())
+	if tf == nil {
+		return false
+	}
+	filename := filepath.ToSlash(tf.Name())
+	return strings.HasSuffix(filename, "_test.go")
+}
+
+func parentMap(file *ast.File) map[ast.Node]ast.Node {
+	parents := make(map[ast.Node]ast.Node)
+	var stack []ast.Node
+	ast.Inspect(file, func(node ast.Node) bool {
+		if node == nil {
+			stack = stack[:len(stack)-1]
+			return true
+		}
+		if len(stack) > 0 {
+			parents[node] = stack[len(stack)-1]
+		}
+		stack = append(stack, node)
+		return true
+	})
+	return parents
+}
+
+func checkCompositeLiteral(pass *analysis.Pass, r reporter, lit *ast.CompositeLit) {
+	typeName, ok := pgtypeName(pass.TypesInfo.TypeOf(lit.Type))
+	if !ok {
+		return
+	}
+
+	rule, ok := pgtypeRules[typeName]
+	if !ok {
+		return
+	}
+
+	fields := compositeFields(lit)
+	valueField := firstPresentField(fields, rule.valueFields)
+	if valueField == "" {
+		return
+	}
+
+	display := encodeSuggestion(pass, rule, fields[valueField], fields["Valid"])
+	var fixes []analysis.SuggestedFix
+	if replacement, ok := r.encodeReplacement(rule, typeName, valueField, fields); ok {
+		fixes = []analysis.SuggestedFix{r.replaceWithPackage(lit.Pos(), lit.End(), replacement.text, "Replace with "+replacement.display, pgencodePath, "pgencode")}
+	}
+
+	r.report(lit.Lbrace, lit.End(), fmt.Sprintf("manual pgtype.%s encode; use %s", typeName, display), fixes)
+}
+
+func checkSelector(pass *analysis.Pass, r reporter, parents map[ast.Node]ast.Node, sel *ast.SelectorExpr) {
+	typeName, ok := pgtypeName(pass.TypesInfo.TypeOf(sel.X))
+	if !ok {
+		return
+	}
+
+	rule, ok := pgtypeRules[typeName]
+	if !ok || !slices.Contains(rule.valueFields, sel.Sel.Name) {
+		return
+	}
+
+	if isAssignmentTarget(parents, sel) {
+		var fixes []analysis.SuggestedFix
+		if fix, ok := r.assignmentTargetFix(parents, rule, typeName, sel); ok {
+			fixes = []analysis.SuggestedFix{fix}
+		}
+		r.report(sel.Sel.Pos(), sel.Sel.End(), fmt.Sprintf("manual pgtype.%s field assignment; build the value with pgencode instead of setting .%s", typeName, sel.Sel.Name), fixes)
+		return
+	}
+
+	guarded := isGuardedDecode(pass, parents, sel)
+	if !(guarded && isAssignmentValue(parents, sel)) && !(guarded && isTinyDecodeHelper(pass, parents, sel)) {
+		return
+	}
+
+	var fixes []analysis.SuggestedFix
+	if fix, ok := r.fillDecodeFix(parents, rule, typeName, sel); ok {
+		fixes = []analysis.SuggestedFix{fix}
+	} else if fix, ok := r.valueDecodeFix(rule, sel); ok {
+		fixes = []analysis.SuggestedFix{fix}
+	}
+
+	r.report(sel.Sel.Pos(), sel.Sel.End(), fmt.Sprintf("manual pgtype.%s decode; use pgdecode.%s(...).Value/Ptr/Fill instead of .%s", typeName, rule.decodeFunc, sel.Sel.Name), fixes)
+}
+
+func checkWrapperCall(pass *analysis.Pass, r reporter, wrappers map[*types.Func]tinyWrapper, call *ast.CallExpr) {
+	ident, ok := call.Fun.(*ast.Ident)
+	if !ok {
+		return
+	}
+
+	fn, ok := pass.TypesInfo.Uses[ident].(*types.Func)
+	if !ok {
+		return
+	}
+
+	wrapper, ok := wrappers[fn]
+	if !ok || wrapper.expr == nil || len(wrapper.params) != len(call.Args) {
+		return
+	}
+
+	fix, ok := r.inlineWrapperFix(wrapper, call)
+	if !ok {
+		return
+	}
+
+	r.report(call.Pos(), call.End(), fmt.Sprintf("call to tiny %s wrapper %s; use %s directly", wrapper.kind, wrapper.name, wrapper.kind), []analysis.SuggestedFix{fix})
+}
+
+func (r reporter) report(pos, end token.Pos, message string, fixes []analysis.SuggestedFix) {
+	if r.ignores.Ignored(pos, analyzerName) {
+		return
+	}
+	r.pass.Report(analysis.Diagnostic{
+		Pos:            pos,
+		End:            end,
+		Message:        message,
+		SuggestedFixes: fixes,
+	})
+}
+
+func compositeFields(lit *ast.CompositeLit) map[string]ast.Expr {
+	fields := make(map[string]ast.Expr)
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		fields[key.Name] = kv.Value
+	}
+	return fields
+}
+
+func paramNameList(fields *ast.FieldList) []string {
+	if fields == nil {
+		return nil
+	}
+	var names []string
+	for _, field := range fields.List {
+		for _, name := range field.Names {
+			names = append(names, name.Name)
+		}
+	}
+	return names
+}
+
+func containsPgconvParamCall(pass *analysis.Pass, expr ast.Expr, params map[string]bool) (pgconvUse, bool) {
+	call, ok := unparen(expr).(*ast.CallExpr)
+	if !ok {
+		return pgconvUse{}, false
+	}
+	if use, ok := pgconvCallKind(pass, call); ok && callUsesParam(call, params) {
+		return use, true
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return pgconvUse{}, false
+	}
+	return containsPgconvParamCall(pass, sel.X, params)
+}
+
+func pgconvCallKind(pass *analysis.Pass, call *ast.CallExpr) (pgconvUse, bool) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return pgconvUse{}, false
+	}
+	fn, ok := pass.TypesInfo.Uses[sel.Sel].(*types.Func)
+	if !ok || fn.Pkg() == nil {
+		return pgconvUse{}, false
+	}
+	qualifier, _ := selectorQualifier(sel)
+	switch fn.Pkg().Path() {
+	case pgencodePath:
+		return pgconvUse{kind: "pgencode", qualifier: qualifier}, true
+	case pgdecodePath:
+		return pgconvUse{kind: "pgdecode", qualifier: qualifier}, true
+	default:
+		return pgconvUse{}, false
+	}
+}
+
+func selectorQualifier(sel *ast.SelectorExpr) (string, bool) {
+	ident, ok := unparen(sel.X).(*ast.Ident)
+	if !ok {
+		return "", false
+	}
+	return ident.Name, true
+}
+
+func callUsesParam(call *ast.CallExpr, params map[string]bool) bool {
+	for _, arg := range call.Args {
+		if params[rootIdent(arg)] {
+			return true
+		}
+	}
+	return false
+}
+
+func rootIdent(expr ast.Expr) string {
+	switch e := unparen(expr).(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.SelectorExpr:
+		return rootIdent(e.X)
+	case *ast.StarExpr:
+		return rootIdent(e.X)
+	default:
+		return ""
+	}
+}
+
+func firstPresentField(fields map[string]ast.Expr, names []string) string {
+	for _, name := range names {
+		if _, ok := fields[name]; ok {
+			return name
+		}
+	}
+	return ""
+}
+
+func encodeSuggestion(pass *analysis.Pass, rule pgtypeRule, value, valid ast.Expr) string {
+	if value == nil {
+		return fmt.Sprintf("pgencode.%s(...).%s()", rule.encodeFunc, rule.encodeMethod)
+	}
+
+	if ptr := dereferencedExpr(value); ptr != nil && isNotNilCheck(valid, ptr, pass.Fset) {
+		return fmt.Sprintf("pgencode.%sPtr(...).%s()", rule.encodeFunc, rule.encodeMethod)
+	}
+
+	if rule.encodeFunc == "String" && isNonEmptyStringCheck(valid, value, pass.Fset) {
+		return fmt.Sprintf("pgencode.%s(...).EmptyIsNull().%s()", rule.encodeFunc, rule.encodeMethod)
+	}
+
+	return fmt.Sprintf("pgencode.%s(...).%s()", rule.encodeFunc, rule.encodeMethod)
+}
+
+func (r reporter) encodeReplacement(rule pgtypeRule, typeName, valueField string, fields map[string]ast.Expr) (encodeReplacement, bool) {
+	value := fields[valueField]
+	valid := fields["Valid"]
+	if value == nil || !safeCompositeFields(typeName, valueField, fields, r.pass.Fset) {
+		return encodeReplacement{}, false
+	}
+
+	qualifier, ok := r.packageQualifier(pgencodePath, "pgencode")
+	if !ok {
+		return encodeReplacement{}, false
+	}
+
+	fn := rule.encodeFunc
+	arg := renderNode(r.pass.Fset, value)
+	chain := ""
+	ptr := dereferencedExpr(value)
+	switch {
+	case isTrue(valid):
+	case ptr != nil && isNotNilCheck(valid, ptr, r.pass.Fset):
+		fn += "Ptr"
+		arg = renderNode(r.pass.Fset, ptr)
+	case rule.encodeFunc == "String" && isNonEmptyStringCheck(valid, value, r.pass.Fset):
+		chain = ".EmptyIsNull()"
+	default:
+		return encodeReplacement{}, false
+	}
+
+	text := fmt.Sprintf("%s.%s(%s)%s.%s()", qualifier, fn, arg, chain, rule.encodeMethod)
+	display := fmt.Sprintf("pgencode.%s(%s)%s.%s()", fn, arg, chain, rule.encodeMethod)
+	return encodeReplacement{text: text, display: display}, true
+}
+
+func safeCompositeFields(typeName, valueField string, fields map[string]ast.Expr, fset *token.FileSet) bool {
+	for field, expr := range fields {
+		switch field {
+		case valueField, "Valid":
+			continue
+		case "InfinityModifier":
+			if typeName == "Date" || typeName == "Timestamp" || typeName == "Timestamptz" {
+				rendered := renderNode(fset, expr)
+				if rendered == "pgtype.Finite" || rendered == "0" {
+					continue
+				}
+			}
+			return false
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func (r reporter) assignmentTargetFix(parents map[ast.Node]ast.Node, rule pgtypeRule, typeName string, sel *ast.SelectorExpr) (analysis.SuggestedFix, bool) {
+	assign, ok := parents[sel].(*ast.AssignStmt)
+	if !ok || assign.Tok != token.ASSIGN || len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
+		return analysis.SuggestedFix{}, false
+	}
+
+	block, index, ok := enclosingBlock(parents, assign)
+	if !ok {
+		return analysis.SuggestedFix{}, false
+	}
+
+	value := assign.Rhs[0]
+	target := sel.X
+	var validAssign *ast.AssignStmt
+	for _, candidateIndex := range []int{index - 1, index + 1} {
+		if candidateIndex < 0 || candidateIndex >= len(block.List) {
+			continue
+		}
+		candidate, ok := block.List[candidateIndex].(*ast.AssignStmt)
+		if !ok || candidate.Tok != token.ASSIGN || len(candidate.Lhs) != 1 || len(candidate.Rhs) != 1 {
+			continue
+		}
+		if isValidFieldAssignment(candidate.Lhs[0], target, r.pass.Fset) {
+			validAssign = candidate
+			break
+		}
+	}
+	if validAssign == nil {
+		return analysis.SuggestedFix{}, false
+	}
+
+	fields := map[string]ast.Expr{
+		rule.valueFields[0]: value,
+		"Valid":             validAssign.Rhs[0],
+	}
+	replacement, ok := r.encodeReplacement(rule, typeName, rule.valueFields[0], fields)
+	if !ok {
+		return analysis.SuggestedFix{}, false
+	}
+
+	start, end := assign.Pos(), assign.End()
+	if validAssign.Pos() < start {
+		start = validAssign.Pos()
+	}
+	if validAssign.End() > end {
+		end = validAssign.End()
+	}
+
+	text := fmt.Sprintf("%s = %s", renderNode(r.pass.Fset, target), replacement.text)
+	return r.replaceWithPackage(start, end, text, "Replace field assignments with "+replacement.display, pgencodePath, "pgencode"), true
+}
+
+func isValidFieldAssignment(expr ast.Expr, target ast.Expr, fset *token.FileSet) bool {
+	sel, ok := unparen(expr).(*ast.SelectorExpr)
+	return ok && sel.Sel.Name == "Valid" && sameExpr(sel.X, target, fset)
+}
+
+func enclosingBlock(parents map[ast.Node]ast.Node, stmt ast.Stmt) (*ast.BlockStmt, int, bool) {
+	block, ok := parents[stmt].(*ast.BlockStmt)
+	if !ok {
+		return nil, -1, false
+	}
+	for i, candidate := range block.List {
+		if candidate == stmt {
+			return block, i, true
+		}
+	}
+	return nil, -1, false
+}
+
+func (r reporter) fillDecodeFix(parents map[ast.Node]ast.Node, rule pgtypeRule, typeName string, sel *ast.SelectorExpr) (analysis.SuggestedFix, bool) {
+	if typeName == "UUID" {
+		return analysis.SuggestedFix{}, false
+	}
+
+	ifStmt := enclosingIfForDecode(parents, sel)
+	if ifStmt == nil || ifStmt.Else != nil || len(ifStmt.Body.List) != 1 {
+		return analysis.SuggestedFix{}, false
+	}
+
+	assign, ok := ifStmt.Body.List[0].(*ast.AssignStmt)
+	if !ok || assign.Tok != token.ASSIGN || len(assign.Lhs) != 1 || len(assign.Rhs) != 1 || !containsNode(assign.Rhs[0], sel.Pos()) {
+		return analysis.SuggestedFix{}, false
+	}
+	if !simpleAddressable(assign.Lhs[0]) {
+		return analysis.SuggestedFix{}, false
+	}
+
+	qualifier, ok := r.packageQualifier(pgdecodePath, "pgdecode")
+	if !ok {
+		return analysis.SuggestedFix{}, false
+	}
+	text := fmt.Sprintf("%s.%s(%s).Fill(&%s)", qualifier, rule.decodeFunc, renderNode(r.pass.Fset, sel.X), renderNode(r.pass.Fset, assign.Lhs[0]))
+	return r.replaceWithPackage(ifStmt.Pos(), ifStmt.End(), text, "Replace guarded assignment with pgdecode."+rule.decodeFunc+"(...).Fill", pgdecodePath, "pgdecode"), true
+}
+
+func enclosingIfForDecode(parents map[ast.Node]ast.Node, sel *ast.SelectorExpr) *ast.IfStmt {
+	for node := ast.Node(sel); node != nil; node = parents[node] {
+		if ifStmt, ok := parents[node].(*ast.IfStmt); ok {
+			return ifStmt
+		}
+		switch parents[node].(type) {
+		case *ast.FuncDecl, *ast.FuncLit:
+			return nil
+		}
+	}
+	return nil
+}
+
+func simpleAddressable(expr ast.Expr) bool {
+	switch e := unparen(expr).(type) {
+	case *ast.Ident:
+		return true
+	case *ast.SelectorExpr:
+		return simpleAddressable(e.X)
+	case *ast.StarExpr:
+		return true
+	default:
+		return false
+	}
+}
+
+func (r reporter) valueDecodeFix(rule pgtypeRule, sel *ast.SelectorExpr) (analysis.SuggestedFix, bool) {
+	qualifier, ok := r.packageQualifier(pgdecodePath, "pgdecode")
+	if !ok {
+		return analysis.SuggestedFix{}, false
+	}
+	text := fmt.Sprintf("%s.%s(%s).Value()", qualifier, rule.decodeFunc, renderNode(r.pass.Fset, sel.X))
+	return r.replaceWithPackage(sel.Pos(), sel.End(), text, "Replace with pgdecode."+rule.decodeFunc+"(...).Value", pgdecodePath, "pgdecode"), true
+}
+
+func (r reporter) inlineWrapperFix(wrapper tinyWrapper, call *ast.CallExpr) (analysis.SuggestedFix, bool) {
+	pkgPath := pgencodePath
+	defaultName := "pgencode"
+	if wrapper.kind == "pgdecode" {
+		pkgPath = pgdecodePath
+		defaultName = "pgdecode"
+	}
+
+	qualifier, ok := r.packageQualifier(pkgPath, defaultName)
+	if !ok {
+		return analysis.SuggestedFix{}, false
+	}
+
+	replacement, ok := inlineExpression(r.pass.Fset, wrapper, call.Args, qualifier)
+	if !ok {
+		return analysis.SuggestedFix{}, false
+	}
+
+	return r.replaceWithPackage(call.Pos(), call.End(), replacement, "Inline "+wrapper.kind+" wrapper "+wrapper.name, pkgPath, defaultName), true
+}
+
+func inlineExpression(fset *token.FileSet, wrapper tinyWrapper, args []ast.Expr, qualifier string) (string, bool) {
+	source := renderNode(fset, wrapper.expr)
+	expr, err := parser.ParseExpr(source)
+	if err != nil {
+		return "", false
+	}
+
+	argText := make(map[string]string, len(args))
+	for i, param := range wrapper.params {
+		argText[param] = renderNode(fset, args[i])
+	}
+
+	ok := true
+	astutil.Apply(expr, func(cursor *astutil.Cursor) bool {
+		ident, isIdent := cursor.Node().(*ast.Ident)
+		if !isIdent {
+			return true
+		}
+		if text, exists := argText[ident.Name]; exists {
+			replacement, err := parser.ParseExpr(text)
+			if err != nil {
+				ok = false
+				return false
+			}
+			cursor.Replace(replacement)
+			return true
+		}
+		if ident.Name == wrapper.qualifier && qualifier != "" {
+			cursor.Replace(ast.NewIdent(qualifier))
+		}
+		return true
+	}, nil)
+	if !ok {
+		return "", false
+	}
+
+	var buf bytes.Buffer
+	if err := format.Node(&buf, fset, expr); err != nil {
+		return "", false
+	}
+	return buf.String(), true
+}
+
+func (r reporter) replaceWithPackage(start, end token.Pos, text, message, pkgPath, defaultName string) analysis.SuggestedFix {
+	_, importEdits, _ := r.importFor(pkgPath, defaultName)
+	edits := append([]analysis.TextEdit{}, importEdits...)
+	edits = append(edits, analysis.TextEdit{Pos: start, End: end, NewText: []byte(text)})
+	return analysis.SuggestedFix{Message: message, TextEdits: edits}
+}
+
+func (r reporter) packageQualifier(pkgPath, defaultName string) (string, bool) {
+	qualifier, _, ok := r.importFor(pkgPath, defaultName)
+	return qualifier, ok
+}
+
+func (r reporter) importFor(pkgPath, defaultName string) (string, []analysis.TextEdit, bool) {
+	if qualifier, ok := importedQualifier(r.file, pkgPath); ok {
+		return qualifier, nil, qualifier != ""
+	}
+
+	qualifier := uniqueImportName(r.file, defaultName)
+	edits, ok := addImportEdits(r.pass.Fset, r.file, qualifier, defaultName, pkgPath)
+	return qualifier, edits, ok
+}
+
+func importedQualifier(file *ast.File, pkgPath string) (string, bool) {
+	for _, spec := range file.Imports {
+		if strings.Trim(spec.Path.Value, `"`) != pkgPath {
+			continue
+		}
+		if spec.Name == nil {
+			return path.Base(pkgPath), true
+		}
+		if spec.Name.Name == "_" || spec.Name.Name == "." {
+			return "", true
+		}
+		return spec.Name.Name, true
+	}
+	return "", false
+}
+
+func uniqueImportName(file *ast.File, defaultName string) string {
+	used := fileLevelNames(file)
+	if !used[defaultName] {
+		return defaultName
+	}
+	for i := 1; ; i++ {
+		candidate := fmt.Sprintf("%s%d", defaultName, i)
+		if !used[candidate] {
+			return candidate
+		}
+	}
+}
+
+func fileLevelNames(file *ast.File) map[string]bool {
+	used := make(map[string]bool)
+	for _, spec := range file.Imports {
+		if spec.Name != nil {
+			used[spec.Name.Name] = true
+			continue
+		}
+		used[path.Base(strings.Trim(spec.Path.Value, `"`))] = true
+	}
+	for _, decl := range file.Decls {
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			if d.Name != nil {
+				used[d.Name.Name] = true
+			}
+		case *ast.GenDecl:
+			for _, spec := range d.Specs {
+				switch s := spec.(type) {
+				case *ast.TypeSpec:
+					used[s.Name.Name] = true
+				case *ast.ValueSpec:
+					for _, name := range s.Names {
+						used[name.Name] = true
+					}
+				}
+			}
+		}
+	}
+	return used
+}
+
+func addImportEdits(fset *token.FileSet, file *ast.File, qualifier, defaultName, pkgPath string) ([]analysis.TextEdit, bool) {
+	specText := importSpecText(qualifier, defaultName, pkgPath)
+	importDecl := firstImportDecl(file)
+	if importDecl == nil {
+		return []analysis.TextEdit{{
+			Pos:     file.Name.End(),
+			End:     file.Name.End(),
+			NewText: []byte("\n\nimport " + specText + "\n"),
+		}}, true
+	}
+
+	if importDecl.Lparen.IsValid() {
+		return []analysis.TextEdit{{
+			Pos:     importDecl.Rparen,
+			End:     importDecl.Rparen,
+			NewText: []byte("\n\t" + specText),
+		}}, true
+	}
+
+	if len(importDecl.Specs) != 1 {
+		return nil, false
+	}
+	existing := renderNode(fset, importDecl.Specs[0])
+	if existing == "" {
+		return nil, false
+	}
+	text := fmt.Sprintf("import (\n\t%s\n\t%s\n)", existing, specText)
+	return []analysis.TextEdit{{
+		Pos:     importDecl.Pos(),
+		End:     importDecl.End(),
+		NewText: []byte(text),
+	}}, true
+}
+
+func importSpecText(qualifier, defaultName, pkgPath string) string {
+	if qualifier != defaultName {
+		return fmt.Sprintf("%s %q", qualifier, pkgPath)
+	}
+	return fmt.Sprintf("%q", pkgPath)
+}
+
+func firstImportDecl(file *ast.File) *ast.GenDecl {
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if ok && gen.Tok == token.IMPORT {
+			return gen
+		}
+	}
+	return nil
+}
+
+func dereferencedExpr(expr ast.Expr) ast.Expr {
+	star, ok := unparen(expr).(*ast.StarExpr)
+	if !ok {
+		return nil
+	}
+	return star.X
+}
+
+func isNonEmptyStringCheck(expr, value ast.Expr, fset *token.FileSet) bool {
+	bin, ok := unparen(expr).(*ast.BinaryExpr)
+	if !ok || bin.Op != token.NEQ {
+		return false
+	}
+	return (sameExpr(bin.X, value, fset) && isEmptyString(bin.Y)) ||
+		(sameExpr(bin.Y, value, fset) && isEmptyString(bin.X))
+}
+
+func isNotNilCheck(expr, value ast.Expr, fset *token.FileSet) bool {
+	bin, ok := unparen(expr).(*ast.BinaryExpr)
+	if !ok || bin.Op != token.NEQ {
+		return false
+	}
+	return (sameExpr(bin.X, value, fset) && isNilIdent(bin.Y)) ||
+		(sameExpr(bin.Y, value, fset) && isNilIdent(bin.X))
+}
+
+func isTrue(expr ast.Expr) bool {
+	ident, ok := unparen(expr).(*ast.Ident)
+	return ok && ident.Name == "true"
+}
+
+func unparen(expr ast.Expr) ast.Expr {
+	for {
+		paren, ok := expr.(*ast.ParenExpr)
+		if !ok {
+			return expr
+		}
+		expr = paren.X
+	}
+}
+
+func sameExpr(a, b ast.Expr, fset *token.FileSet) bool {
+	return renderNode(fset, a) == renderNode(fset, b)
+}
+
+func renderNode(fset *token.FileSet, node ast.Node) string {
+	var buf bytes.Buffer
+	if err := format.Node(&buf, fset, node); err != nil {
+		return ""
+	}
+	return buf.String()
+}
+
+func isEmptyString(expr ast.Expr) bool {
+	lit, ok := unparen(expr).(*ast.BasicLit)
+	return ok && lit.Kind == token.STRING && lit.Value == `""`
+}
+
+func isNilIdent(expr ast.Expr) bool {
+	ident, ok := unparen(expr).(*ast.Ident)
+	return ok && ident.Name == "nil"
+}
+
+func isAssignmentTarget(parents map[ast.Node]ast.Node, sel *ast.SelectorExpr) bool {
+	parent := parents[sel]
+	switch p := parent.(type) {
+	case *ast.AssignStmt:
+		return slices.ContainsFunc(p.Lhs, func(expr ast.Expr) bool { return expr == sel })
+	case *ast.IncDecStmt:
+		return p.X == sel
+	}
+	return false
+}
+
+func isAssignmentValue(parents map[ast.Node]ast.Node, sel *ast.SelectorExpr) bool {
+	for node := ast.Node(sel); node != nil; node = parents[node] {
+		switch p := parents[node].(type) {
+		case *ast.AssignStmt:
+			return slices.ContainsFunc(p.Rhs, func(expr ast.Expr) bool { return containsNode(expr, sel.Pos()) })
+		case *ast.FuncDecl, *ast.FuncLit:
+			return false
+		}
+	}
+	return false
+}
+
+func isGuardedDecode(pass *analysis.Pass, parents map[ast.Node]ast.Node, sel *ast.SelectorExpr) bool {
+	for node := parents[sel]; node != nil; node = parents[node] {
+		switch n := node.(type) {
+		case *ast.FuncDecl, *ast.FuncLit:
+			return false
+		case *ast.IfStmt:
+			if containsNode(n.Cond, sel.Pos()) || containsNode(n.Body, sel.Pos()) || (n.Else != nil && containsNode(n.Else, sel.Pos())) {
+				return containsValidCheck(pass, n.Cond, sel.X)
+			}
+		}
+	}
+	return false
+}
+
+func isTinyDecodeHelper(pass *analysis.Pass, parents map[ast.Node]ast.Node, sel *ast.SelectorExpr) bool {
+	for node := parents[sel]; node != nil; node = parents[node] {
+		switch n := node.(type) {
+		case *ast.FuncDecl:
+			if n.Body == nil || len(n.Body.List) > 5 || returnsPgtype(pass, n.Type.Results) {
+				return false
+			}
+			return fieldListHasPgtype(pass, n.Type.Params) || fieldListHasPgtype(pass, n.Recv)
+		case *ast.FuncLit:
+			if n.Body == nil || len(n.Body.List) > 5 || returnsPgtype(pass, n.Type.Results) {
+				return false
+			}
+			return fieldListHasPgtype(pass, n.Type.Params)
+		}
+	}
+	return false
+}
+
+func containsNode(node ast.Node, pos token.Pos) bool {
+	return node != nil && node.Pos() <= pos && pos < node.End()
+}
+
+func containsValidCheck(pass *analysis.Pass, expr ast.Expr, target ast.Expr) bool {
+	found := false
+	ast.Inspect(expr, func(node ast.Node) bool {
+		if found {
+			return false
+		}
+		sel, ok := node.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Valid" {
+			return true
+		}
+		if _, ok := pgtypeName(pass.TypesInfo.TypeOf(sel.X)); ok && sameExpr(sel.X, target, pass.Fset) {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+func returnsPgtype(pass *analysis.Pass, fields *ast.FieldList) bool {
+	return fieldListHasPgtype(pass, fields)
+}
+
+func fieldListHasPgtype(pass *analysis.Pass, fields *ast.FieldList) bool {
+	if fields == nil {
+		return false
+	}
+	for _, field := range fields.List {
+		if _, ok := pgtypeName(pass.TypesInfo.TypeOf(field.Type)); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func pgtypeName(t types.Type) (string, bool) {
+	t = derefType(t)
+	named, ok := t.(*types.Named)
+	if !ok {
+		return "", false
+	}
+	obj := named.Obj()
+	if obj == nil || obj.Pkg() == nil || obj.Pkg().Path() != pgtypePath {
+		return "", false
+	}
+	return obj.Name(), true
+}
+
+func derefType(t types.Type) types.Type {
+	for {
+		ptr, ok := t.(*types.Pointer)
+		if !ok {
+			return t
+		}
+		t = ptr.Elem()
+	}
+}

--- a/pgconv/pgconvlint/analyzer_test.go
+++ b/pgconv/pgconvlint/analyzer_test.go
@@ -1,0 +1,11 @@
+package pgconvlint
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestAnalyzer(t *testing.T) {
+	analysistest.RunWithSuggestedFixes(t, analysistest.TestData(), Analyzer, "a", "fileignore", "imports")
+}

--- a/pgconv/pgconvlint/doc.go
+++ b/pgconv/pgconvlint/doc.go
@@ -1,0 +1,8 @@
+// Package pgconvlint provides a Go analyzer for finding manual pgtype
+// conversions that should use pgencode or pgdecode.
+//
+// The analyzer reports direct pgtype composite-literal encodes, guarded
+// pgtype field decodes, adjacent value/Valid field assignments, and tiny
+// package-local pgconv wrapper helpers. Safe mechanical diagnostics include
+// SuggestedFix values that editors and compatible analyzer drivers can apply.
+package pgconvlint

--- a/pgconv/pgconvlint/testdata/src/a/a.go
+++ b/pgconv/pgconvlint/testdata/src/a/a.go
@@ -1,0 +1,104 @@
+package a
+
+import (
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/omniaura/go-kit/pgconv/pgdecode"
+	"github.com/omniaura/go-kit/pgconv/pgencode"
+)
+
+func encode(s string, p *string, b bool, n int64, tm time.Time, id [16]byte) {
+	_ = pgtype.Text{String: s, Valid: true}       // want "manual pgtype.Text encode; use pgencode.String"
+	_ = pgtype.Text{String: s, Valid: s != ""}    // want "manual pgtype.Text encode; use pgencode.String\\(\\.\\.\\.\\).EmptyIsNull\\(\\).Text\\(\\)"
+	_ = pgtype.Text{String: *p, Valid: p != nil}  // want "manual pgtype.Text encode; use pgencode.StringPtr"
+	_ = pgtype.Bool{Bool: b, Valid: true}         // want "manual pgtype.Bool encode; use pgencode.Bool"
+	_ = pgtype.Int8{Int64: n, Valid: true}        // want "manual pgtype.Int8 encode; use pgencode.Int64"
+	_ = pgtype.Timestamptz{Time: tm, Valid: true} // want "manual pgtype.Timestamptz encode; use pgencode.Time"
+	_ = pgtype.UUID{Bytes: id, Valid: true}       // want "manual pgtype.UUID encode; use pgencode.UUID"
+	_ = pgtype.Text{String: s}                    // want "manual pgtype.Text encode; use pgencode.String"
+	//lint:ignore pgconvlint legacy test fixture
+	_ = pgtype.Text{String: s, Valid: true}
+	_ = pgtype.Text{}             // zero/null literals are allowed
+	_ = pgtype.Int8{Valid: false} // explicit null literals are allowed
+}
+
+func decode(txt pgtype.Text, ts pgtype.Timestamptz, id pgtype.UUID) {
+	var out struct {
+		Name string
+		Time time.Time
+		ID   [16]byte
+	}
+	if txt.Valid {
+		out.Name = txt.String // want "manual pgtype.Text decode; use pgdecode.Text"
+	}
+	if ts.Valid {
+		out.Time = ts.Time // want "manual pgtype.Timestamptz decode; use pgdecode.Timestamptz"
+	}
+	if id.Valid {
+		out.ID = id.Bytes // want "manual pgtype.UUID decode; use pgdecode.UUID"
+	}
+
+	_ = struct {
+		CreatedAt time.Time
+	}{CreatedAt: ts.Time}
+}
+
+func textValue(txt pgtype.Text) string {
+	if txt.Valid {
+		return txt.String // want "manual pgtype.Text decode; use pgdecode.Text"
+	}
+	return ""
+}
+
+func assign(txt pgtype.Text, value string) {
+	txt.String = value // want "manual pgtype.Text field assignment; build the value with pgencode"
+	txt.Valid = true
+}
+
+func pgText(s string) pgtype.Text { // want "tiny pgencode wrapper pgText; call pgencode directly at the use site"
+	return pgencode.String(s).EmptyIsNull().Text()
+}
+
+func pgBool(b bool) pgtype.Bool { // want "tiny pgencode wrapper pgBool; call pgencode directly at the use site"
+	return pgencode.Bool(b).Bool()
+}
+
+type wrappedTime struct {
+	Time  time.Time
+	Valid bool
+}
+
+func toPgTimestamptz(t wrappedTime) pgtype.Timestamptz { // want "tiny pgencode wrapper toPgTimestamptz; call pgencode directly at the use site"
+	if !t.Valid {
+		return pgtype.Timestamptz{}
+	}
+	return pgencode.Time(t.Time).Timestamptz()
+}
+
+func decodeText(t pgtype.Text) string { // want "tiny pgdecode wrapper decodeText; call pgdecode directly at the use site"
+	return pgdecode.Text(t).Value()
+}
+
+//lint:ignore pgconvlint legacy wrapper kept for compatibility
+func ignoredDecodeText(t pgtype.Text) string {
+	return pgdecode.Text(t).Value()
+}
+
+func usesWrappers(s string, b bool, t pgtype.Text) {
+	_ = pgText(s)     // want "call to tiny pgencode wrapper pgText; use pgencode directly"
+	_ = pgBool(b)     // want "call to tiny pgencode wrapper pgBool; use pgencode directly"
+	_ = decodeText(t) // want "call to tiny pgdecode wrapper decodeText; use pgdecode directly"
+}
+
+type row struct {
+	Name pgtype.Text
+}
+
+type response struct {
+	Name string
+}
+
+func mapper(r row) response {
+	return response{Name: pgdecode.Text(r.Name).Value()}
+}

--- a/pgconv/pgconvlint/testdata/src/a/a.go.golden
+++ b/pgconv/pgconvlint/testdata/src/a/a.go.golden
@@ -1,0 +1,99 @@
+package a
+
+import (
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/omniaura/go-kit/pgconv/pgdecode"
+	"github.com/omniaura/go-kit/pgconv/pgencode"
+)
+
+func encode(s string, p *string, b bool, n int64, tm time.Time, id [16]byte) {
+	_ = pgencode.String(s).Text()               // want "manual pgtype.Text encode; use pgencode.String"
+	_ = pgencode.String(s).EmptyIsNull().Text() // want "manual pgtype.Text encode; use pgencode.String\\(\\.\\.\\.\\).EmptyIsNull\\(\\).Text\\(\\)"
+	_ = pgencode.StringPtr(p).Text()            // want "manual pgtype.Text encode; use pgencode.StringPtr"
+	_ = pgencode.Bool(b).Bool()                 // want "manual pgtype.Bool encode; use pgencode.Bool"
+	_ = pgencode.Int64(n).Int8()                // want "manual pgtype.Int8 encode; use pgencode.Int64"
+	_ = pgencode.Time(tm).Timestamptz()         // want "manual pgtype.Timestamptz encode; use pgencode.Time"
+	_ = pgencode.UUID(id).UUID()                // want "manual pgtype.UUID encode; use pgencode.UUID"
+	_ = pgtype.Text{String: s}                  // want "manual pgtype.Text encode; use pgencode.String"
+	//lint:ignore pgconvlint legacy test fixture
+	_ = pgtype.Text{String: s, Valid: true}
+	_ = pgtype.Text{}             // zero/null literals are allowed
+	_ = pgtype.Int8{Valid: false} // explicit null literals are allowed
+}
+
+func decode(txt pgtype.Text, ts pgtype.Timestamptz, id pgtype.UUID) {
+	var out struct {
+		Name string
+		Time time.Time
+		ID   [16]byte
+	}
+	pgdecode.Text(txt).Fill(&out.Name)
+	pgdecode.Timestamptz(ts).Fill(&out.Time)
+	if id.Valid {
+		out.ID = pgdecode.UUID(id).Value() // want "manual pgtype.UUID decode; use pgdecode.UUID"
+	}
+
+	_ = struct {
+		CreatedAt time.Time
+	}{CreatedAt: ts.Time}
+}
+
+func textValue(txt pgtype.Text) string {
+	if txt.Valid {
+		return pgdecode.Text(txt).Value() // want "manual pgtype.Text decode; use pgdecode.Text"
+	}
+	return ""
+}
+
+func assign(txt pgtype.Text, value string) {
+	txt = pgencode.String(value).Text()
+}
+
+func pgText(s string) pgtype.Text { // want "tiny pgencode wrapper pgText; call pgencode directly at the use site"
+	return pgencode.String(s).EmptyIsNull().Text()
+}
+
+func pgBool(b bool) pgtype.Bool { // want "tiny pgencode wrapper pgBool; call pgencode directly at the use site"
+	return pgencode.Bool(b).Bool()
+}
+
+type wrappedTime struct {
+	Time  time.Time
+	Valid bool
+}
+
+func toPgTimestamptz(t wrappedTime) pgtype.Timestamptz { // want "tiny pgencode wrapper toPgTimestamptz; call pgencode directly at the use site"
+	if !t.Valid {
+		return pgtype.Timestamptz{}
+	}
+	return pgencode.Time(t.Time).Timestamptz()
+}
+
+func decodeText(t pgtype.Text) string { // want "tiny pgdecode wrapper decodeText; call pgdecode directly at the use site"
+	return pgdecode.Text(t).Value()
+}
+
+//lint:ignore pgconvlint legacy wrapper kept for compatibility
+func ignoredDecodeText(t pgtype.Text) string {
+	return pgdecode.Text(t).Value()
+}
+
+func usesWrappers(s string, b bool, t pgtype.Text) {
+	_ = pgencode.String(s).EmptyIsNull().Text() // want "call to tiny pgencode wrapper pgText; use pgencode directly"
+	_ = pgencode.Bool(b).Bool()                 // want "call to tiny pgencode wrapper pgBool; use pgencode directly"
+	_ = pgdecode.Text(t).Value()                // want "call to tiny pgdecode wrapper decodeText; use pgdecode directly"
+}
+
+type row struct {
+	Name pgtype.Text
+}
+
+type response struct {
+	Name string
+}
+
+func mapper(r row) response {
+	return response{Name: pgdecode.Text(r.Name).Value()}
+}

--- a/pgconv/pgconvlint/testdata/src/fileignore/fileignore.go
+++ b/pgconv/pgconvlint/testdata/src/fileignore/fileignore.go
@@ -1,0 +1,8 @@
+//lint:file-ignore pgconvlint legacy file fixture
+package fileignore
+
+import "github.com/jackc/pgx/v5/pgtype"
+
+func encode(s string) {
+	_ = pgtype.Text{String: s, Valid: true}
+}

--- a/pgconv/pgconvlint/testdata/src/github.com/jackc/pgx/v5/pgtype/pgtype.go
+++ b/pgconv/pgconvlint/testdata/src/github.com/jackc/pgx/v5/pgtype/pgtype.go
@@ -1,0 +1,53 @@
+package pgtype
+
+import "time"
+
+type Text struct {
+	String string
+	Valid  bool
+}
+
+type Bool struct {
+	Bool  bool
+	Valid bool
+}
+
+type Int2 struct {
+	Int16 int16
+	Valid bool
+}
+
+type Int4 struct {
+	Int32 int32
+	Valid bool
+}
+
+type Int8 struct {
+	Int64 int64
+	Valid bool
+}
+
+type Float8 struct {
+	Float64 float64
+	Valid   bool
+}
+
+type Date struct {
+	Time  time.Time
+	Valid bool
+}
+
+type Timestamp struct {
+	Time  time.Time
+	Valid bool
+}
+
+type Timestamptz struct {
+	Time  time.Time
+	Valid bool
+}
+
+type UUID struct {
+	Bytes [16]byte
+	Valid bool
+}

--- a/pgconv/pgconvlint/testdata/src/github.com/omniaura/go-kit/pgconv/pgdecode/pgdecode.go
+++ b/pgconv/pgconvlint/testdata/src/github.com/omniaura/go-kit/pgconv/pgdecode/pgdecode.go
@@ -1,0 +1,56 @@
+package pgdecode
+
+import (
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type textDecoder struct {
+	value pgtype.Text
+}
+
+func Text(value pgtype.Text) textDecoder {
+	return textDecoder{value: value}
+}
+
+func (d textDecoder) Value() string {
+	return d.value.String
+}
+
+func (d textDecoder) Fill(ptr *string) {
+	if d.value.Valid {
+		*ptr = d.value.String
+	}
+}
+
+type timeDecoder struct {
+	value time.Time
+	valid bool
+}
+
+func Timestamptz(value pgtype.Timestamptz) timeDecoder {
+	return timeDecoder{value: value.Time, valid: value.Valid}
+}
+
+func (d timeDecoder) Value() time.Time {
+	return d.value
+}
+
+func (d timeDecoder) Fill(ptr *time.Time) {
+	if d.valid {
+		*ptr = d.value
+	}
+}
+
+type uuidDecoder struct {
+	value pgtype.UUID
+}
+
+func UUID(value pgtype.UUID) uuidDecoder {
+	return uuidDecoder{value: value}
+}
+
+func (d uuidDecoder) Value() [16]byte {
+	return d.value.Bytes
+}

--- a/pgconv/pgconvlint/testdata/src/github.com/omniaura/go-kit/pgconv/pgencode/pgencode.go
+++ b/pgconv/pgconvlint/testdata/src/github.com/omniaura/go-kit/pgconv/pgencode/pgencode.go
@@ -1,0 +1,78 @@
+package pgencode
+
+import (
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type textBuilder struct {
+	value string
+}
+
+func String(value string) textBuilder {
+	return textBuilder{value: value}
+}
+
+func StringPtr(value *string) textBuilder {
+	if value == nil {
+		return textBuilder{}
+	}
+	return textBuilder{value: *value}
+}
+
+func (b textBuilder) EmptyIsNull() textBuilder {
+	return b
+}
+
+func (b textBuilder) Text() pgtype.Text {
+	return pgtype.Text{String: b.value, Valid: true}
+}
+
+type boolBuilder struct {
+	value bool
+}
+
+func Bool(value bool) boolBuilder {
+	return boolBuilder{value: value}
+}
+
+func (b boolBuilder) Bool() pgtype.Bool {
+	return pgtype.Bool{Bool: b.value, Valid: true}
+}
+
+type int64Builder struct {
+	value int64
+}
+
+func Int64(value int64) int64Builder {
+	return int64Builder{value: value}
+}
+
+func (b int64Builder) Int8() pgtype.Int8 {
+	return pgtype.Int8{Int64: b.value, Valid: true}
+}
+
+type timeBuilder struct {
+	value time.Time
+}
+
+func Time(value time.Time) timeBuilder {
+	return timeBuilder{value: value}
+}
+
+func (b timeBuilder) Timestamptz() pgtype.Timestamptz {
+	return pgtype.Timestamptz{Time: b.value, Valid: true}
+}
+
+type uuidBuilder struct {
+	value [16]byte
+}
+
+func UUID(value [16]byte) uuidBuilder {
+	return uuidBuilder{value: value}
+}
+
+func (b uuidBuilder) UUID() pgtype.UUID {
+	return pgtype.UUID{Bytes: b.value, Valid: true}
+}

--- a/pgconv/pgconvlint/testdata/src/imports/conflict.go
+++ b/pgconv/pgconvlint/testdata/src/imports/conflict.go
@@ -1,0 +1,9 @@
+package imports
+
+import "github.com/jackc/pgx/v5/pgtype"
+
+var pgencode = struct{}{}
+
+func encodeConflict(s string) pgtype.Text {
+	return pgtype.Text{String: s, Valid: true} // want "manual pgtype.Text encode; use pgencode.String"
+}

--- a/pgconv/pgconvlint/testdata/src/imports/conflict.go.golden
+++ b/pgconv/pgconvlint/testdata/src/imports/conflict.go.golden
@@ -1,0 +1,12 @@
+package imports
+
+import (
+	"github.com/jackc/pgx/v5/pgtype"
+	pgencode1 "github.com/omniaura/go-kit/pgconv/pgencode"
+)
+
+var pgencode = struct{}{}
+
+func encodeConflict(s string) pgtype.Text {
+	return pgencode1.String(s).Text() // want "manual pgtype.Text encode; use pgencode.String"
+}

--- a/pgconv/pgconvlint/testdata/src/imports/decode.go
+++ b/pgconv/pgconvlint/testdata/src/imports/decode.go
@@ -1,0 +1,10 @@
+package imports
+
+import "github.com/jackc/pgx/v5/pgtype"
+
+func decode(txt pgtype.Text) string {
+	if txt.Valid {
+		return txt.String // want "manual pgtype.Text decode; use pgdecode.Text"
+	}
+	return ""
+}

--- a/pgconv/pgconvlint/testdata/src/imports/decode.go.golden
+++ b/pgconv/pgconvlint/testdata/src/imports/decode.go.golden
@@ -1,0 +1,13 @@
+package imports
+
+import (
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/omniaura/go-kit/pgconv/pgdecode"
+)
+
+func decode(txt pgtype.Text) string {
+	if txt.Valid {
+		return pgdecode.Text(txt).Value() // want "manual pgtype.Text decode; use pgdecode.Text"
+	}
+	return ""
+}

--- a/pgconv/pgconvlint/testdata/src/imports/encode.go
+++ b/pgconv/pgconvlint/testdata/src/imports/encode.go
@@ -1,0 +1,7 @@
+package imports
+
+import "github.com/jackc/pgx/v5/pgtype"
+
+func encode(s string) pgtype.Text {
+	return pgtype.Text{String: s, Valid: true} // want "manual pgtype.Text encode; use pgencode.String"
+}

--- a/pgconv/pgconvlint/testdata/src/imports/encode.go.golden
+++ b/pgconv/pgconvlint/testdata/src/imports/encode.go.golden
@@ -1,0 +1,10 @@
+package imports
+
+import (
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/omniaura/go-kit/pgconv/pgencode"
+)
+
+func encode(s string) pgtype.Text {
+	return pgencode.String(s).Text() // want "manual pgtype.Text encode; use pgencode.String"
+}


### PR DESCRIPTION
## Summary
Adds a reusable `pgconvlint` analyzer to the `pgconv` module so pgconv can ship its own checker instead of keeping the pgtype conversion lint in downstream repos.

## Changes
- Adds `pgconvlint.Analyzer` plus `cmd/pgconvlint` using `singlechecker`.
- Emits `SuggestedFix` edits for safe pgencode/pgdecode rewrites: pgtype literals, guarded decodes, adjacent value/Valid assignments, missing imports, import aliases, and simple tiny-wrapper call sites.
- Keeps diagnostics report-only where an edit could change behavior, such as omitted `Valid` fields or nontrivial wrappers.
- Adds analysistest fixtures with golden suggested-fix output.

## Test plan
- [x] `go test ./...` from `pgconv/`
- [x] `go run ./cmd/pgconvlint ./...` from `pgconv/`
- [x] `./scripts/test-all.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new lint command for checking Go code.
  * Introduced lint rules and test coverage for spotting manual value conversions and suggesting safer helpers.
  * Added support files for reusable encode/decode helpers and lint suppression comments.

* **Bug Fixes**
  * Improved detection of manual conversion patterns and import conflicts.
  * Respects file-level and inline lint ignore directives.

* **Tests**
  * Added analyzer test cases and golden fixtures covering encoding, decoding, wrappers, and imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->