### PR TITLE
feat(pgconv): ZeroIsNull() int/float encoders + pgconvlint suggestions

### DIFF
--- a/pgconv/pgconvlint/analyzer.go
+++ b/pgconv/pgconvlint/analyzer.go
@@ -45,6 +45,11 @@ type pgtypeRule struct {
 	encodeFunc   string
 	encodeMethod string
 	decodeFunc   string
+	// zeroIsNull is true when the encode builder exposes a ZeroIsNull() method,
+	// i.e. a `Valid: v != 0` composite literal can be rewritten as
+	// pgencode.Fn(v).ZeroIsNull().Method(). Applies to the integer and float
+	// builders.
+	zeroIsNull bool
 }
 
 type pgconvUse struct {
@@ -83,24 +88,28 @@ var pgtypeRules = map[string]pgtypeRule{
 		encodeFunc:   "Int16",
 		encodeMethod: "Int2",
 		decodeFunc:   "Int2",
+		zeroIsNull:   true,
 	},
 	"Int4": {
 		valueFields:  []string{"Int32"},
 		encodeFunc:   "Int32",
 		encodeMethod: "Int4",
 		decodeFunc:   "Int4",
+		zeroIsNull:   true,
 	},
 	"Int8": {
 		valueFields:  []string{"Int64"},
 		encodeFunc:   "Int64",
 		encodeMethod: "Int8",
 		decodeFunc:   "Int8",
+		zeroIsNull:   true,
 	},
 	"Float8": {
 		valueFields:  []string{"Float64"},
 		encodeFunc:   "Float64",
 		encodeMethod: "Float8",
 		decodeFunc:   "Float8",
+		zeroIsNull:   true,
 	},
 	"Date": {
 		valueFields:  []string{"Time"},
@@ -506,6 +515,10 @@ func encodeSuggestion(pass *analysis.Pass, rule pgtypeRule, value, valid ast.Exp
 		return fmt.Sprintf("pgencode.%s(...).EmptyIsNull().%s()", rule.encodeFunc, rule.encodeMethod)
 	}
 
+	if rule.zeroIsNull && isNonZeroCheck(valid, value, pass.Fset) {
+		return fmt.Sprintf("pgencode.%s(...).ZeroIsNull().%s()", rule.encodeFunc, rule.encodeMethod)
+	}
+
 	return fmt.Sprintf("pgencode.%s(...).%s()", rule.encodeFunc, rule.encodeMethod)
 }
 
@@ -532,6 +545,8 @@ func (r reporter) encodeReplacement(rule pgtypeRule, typeName, valueField string
 		arg = renderNode(r.pass.Fset, ptr)
 	case rule.encodeFunc == "String" && isNonEmptyStringCheck(valid, value, r.pass.Fset):
 		chain = ".EmptyIsNull()"
+	case rule.zeroIsNull && isNonZeroCheck(valid, value, r.pass.Fset):
+		chain = ".ZeroIsNull()"
 	default:
 		return encodeReplacement{}, false
 	}
@@ -904,6 +919,28 @@ func isNonEmptyStringCheck(expr, value ast.Expr, fset *token.FileSet) bool {
 	}
 	return (sameExpr(bin.X, value, fset) && isEmptyString(bin.Y)) ||
 		(sameExpr(bin.Y, value, fset) && isEmptyString(bin.X))
+}
+
+func isNonZeroCheck(expr, value ast.Expr, fset *token.FileSet) bool {
+	bin, ok := unparen(expr).(*ast.BinaryExpr)
+	if !ok || bin.Op != token.NEQ {
+		return false
+	}
+	return (sameExpr(bin.X, value, fset) && isZeroLiteral(bin.Y)) ||
+		(sameExpr(bin.Y, value, fset) && isZeroLiteral(bin.X))
+}
+
+func isZeroLiteral(expr ast.Expr) bool {
+	lit, ok := unparen(expr).(*ast.BasicLit)
+	if !ok || (lit.Kind != token.INT && lit.Kind != token.FLOAT) {
+		return false
+	}
+	switch lit.Value {
+	case "0", "0.0", "0.", ".0":
+		return true
+	default:
+		return false
+	}
 }
 
 func isNotNilCheck(expr, value ast.Expr, fset *token.FileSet) bool {

--- a/pgconv/pgconvlint/testdata/src/a/a.go
+++ b/pgconv/pgconvlint/testdata/src/a/a.go
@@ -8,15 +8,19 @@ import (
 	"github.com/omniaura/go-kit/pgconv/pgencode"
 )
 
-func encode(s string, p *string, b bool, n int64, tm time.Time, id [16]byte) {
-	_ = pgtype.Text{String: s, Valid: true}       // want "manual pgtype.Text encode; use pgencode.String"
-	_ = pgtype.Text{String: s, Valid: s != ""}    // want "manual pgtype.Text encode; use pgencode.String\\(\\.\\.\\.\\).EmptyIsNull\\(\\).Text\\(\\)"
-	_ = pgtype.Text{String: *p, Valid: p != nil}  // want "manual pgtype.Text encode; use pgencode.StringPtr"
-	_ = pgtype.Bool{Bool: b, Valid: true}         // want "manual pgtype.Bool encode; use pgencode.Bool"
-	_ = pgtype.Int8{Int64: n, Valid: true}        // want "manual pgtype.Int8 encode; use pgencode.Int64"
-	_ = pgtype.Timestamptz{Time: tm, Valid: true} // want "manual pgtype.Timestamptz encode; use pgencode.Time"
-	_ = pgtype.UUID{Bytes: id, Valid: true}       // want "manual pgtype.UUID encode; use pgencode.UUID"
-	_ = pgtype.Text{String: s}                    // want "manual pgtype.Text encode; use pgencode.String"
+func encode(s string, p *string, b bool, n int64, f float64, tm time.Time, id [16]byte) {
+	_ = pgtype.Text{String: s, Valid: true}        // want "manual pgtype.Text encode; use pgencode.String"
+	_ = pgtype.Text{String: s, Valid: s != ""}     // want "manual pgtype.Text encode; use pgencode.String\\(\\.\\.\\.\\).EmptyIsNull\\(\\).Text\\(\\)"
+	_ = pgtype.Text{String: *p, Valid: p != nil}   // want "manual pgtype.Text encode; use pgencode.StringPtr"
+	_ = pgtype.Bool{Bool: b, Valid: true}          // want "manual pgtype.Bool encode; use pgencode.Bool"
+	_ = pgtype.Int8{Int64: n, Valid: true}         // want "manual pgtype.Int8 encode; use pgencode.Int64"
+	_ = pgtype.Int8{Int64: n, Valid: n != 0}       // want "manual pgtype.Int8 encode; use pgencode.Int64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Int8\\(\\)"
+	_ = pgtype.Int8{Int64: n, Valid: 0 != n}       // want "manual pgtype.Int8 encode; use pgencode.Int64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Int8\\(\\)"
+	_ = pgtype.Float8{Float64: f, Valid: f != 0}   // want "manual pgtype.Float8 encode; use pgencode.Float64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Float8\\(\\)"
+	_ = pgtype.Float8{Float64: f, Valid: f != 0.0} // want "manual pgtype.Float8 encode; use pgencode.Float64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Float8\\(\\)"
+	_ = pgtype.Timestamptz{Time: tm, Valid: true}  // want "manual pgtype.Timestamptz encode; use pgencode.Time"
+	_ = pgtype.UUID{Bytes: id, Valid: true}        // want "manual pgtype.UUID encode; use pgencode.UUID"
+	_ = pgtype.Text{String: s}                     // want "manual pgtype.Text encode; use pgencode.String"
 	//lint:ignore pgconvlint legacy test fixture
 	_ = pgtype.Text{String: s, Valid: true}
 	_ = pgtype.Text{}             // zero/null literals are allowed

--- a/pgconv/pgconvlint/testdata/src/a/a.go.golden
+++ b/pgconv/pgconvlint/testdata/src/a/a.go.golden
@@ -8,15 +8,19 @@ import (
 	"github.com/omniaura/go-kit/pgconv/pgencode"
 )
 
-func encode(s string, p *string, b bool, n int64, tm time.Time, id [16]byte) {
-	_ = pgencode.String(s).Text()               // want "manual pgtype.Text encode; use pgencode.String"
-	_ = pgencode.String(s).EmptyIsNull().Text() // want "manual pgtype.Text encode; use pgencode.String\\(\\.\\.\\.\\).EmptyIsNull\\(\\).Text\\(\\)"
-	_ = pgencode.StringPtr(p).Text()            // want "manual pgtype.Text encode; use pgencode.StringPtr"
-	_ = pgencode.Bool(b).Bool()                 // want "manual pgtype.Bool encode; use pgencode.Bool"
-	_ = pgencode.Int64(n).Int8()                // want "manual pgtype.Int8 encode; use pgencode.Int64"
-	_ = pgencode.Time(tm).Timestamptz()         // want "manual pgtype.Timestamptz encode; use pgencode.Time"
-	_ = pgencode.UUID(id).UUID()                // want "manual pgtype.UUID encode; use pgencode.UUID"
-	_ = pgtype.Text{String: s}                  // want "manual pgtype.Text encode; use pgencode.String"
+func encode(s string, p *string, b bool, n int64, f float64, tm time.Time, id [16]byte) {
+	_ = pgencode.String(s).Text()                        // want "manual pgtype.Text encode; use pgencode.String"
+	_ = pgencode.String(s).EmptyIsNull().Text()          // want "manual pgtype.Text encode; use pgencode.String\\(\\.\\.\\.\\).EmptyIsNull\\(\\).Text\\(\\)"
+	_ = pgencode.StringPtr(p).Text()                     // want "manual pgtype.Text encode; use pgencode.StringPtr"
+	_ = pgencode.Bool(b).Bool()                          // want "manual pgtype.Bool encode; use pgencode.Bool"
+	_ = pgencode.Int64(n).Int8()                         // want "manual pgtype.Int8 encode; use pgencode.Int64"
+	_ = pgencode.Int64(n).ZeroIsNull().Int8()            // want "manual pgtype.Int8 encode; use pgencode.Int64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Int8\\(\\)"
+	_ = pgencode.Int64(n).ZeroIsNull().Int8()            // want "manual pgtype.Int8 encode; use pgencode.Int64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Int8\\(\\)"
+	_ = pgencode.Float64(f).ZeroIsNull().Float8()        // want "manual pgtype.Float8 encode; use pgencode.Float64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Float8\\(\\)"
+	_ = pgencode.Float64(f).ZeroIsNull().Float8()        // want "manual pgtype.Float8 encode; use pgencode.Float64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Float8\\(\\)"
+	_ = pgencode.Time(tm).Timestamptz()                  // want "manual pgtype.Timestamptz encode; use pgencode.Time"
+	_ = pgencode.UUID(id).UUID()                         // want "manual pgtype.UUID encode; use pgencode.UUID"
+	_ = pgtype.Text{String: s}                           // want "manual pgtype.Text encode; use pgencode.String"
 	//lint:ignore pgconvlint legacy test fixture
 	_ = pgtype.Text{String: s, Valid: true}
 	_ = pgtype.Text{}             // zero/null literals are allowed

--- a/pgconv/pgconvlint/testdata/src/github.com/omniaura/go-kit/pgconv/pgencode/pgencode.go
+++ b/pgconv/pgconvlint/testdata/src/github.com/omniaura/go-kit/pgconv/pgencode/pgencode.go
@@ -49,8 +49,28 @@ func Int64(value int64) int64Builder {
 	return int64Builder{value: value}
 }
 
+func (b int64Builder) ZeroIsNull() int64Builder {
+	return b
+}
+
 func (b int64Builder) Int8() pgtype.Int8 {
 	return pgtype.Int8{Int64: b.value, Valid: true}
+}
+
+type float64Builder struct {
+	value float64
+}
+
+func Float64(value float64) float64Builder {
+	return float64Builder{value: value}
+}
+
+func (b float64Builder) ZeroIsNull() float64Builder {
+	return b
+}
+
+func (b float64Builder) Float8() pgtype.Float8 {
+	return pgtype.Float8{Float64: b.value, Valid: true}
 }
 
 type timeBuilder struct {

--- a/pgconv/pgencode/pgencode.go
+++ b/pgconv/pgencode/pgencode.go
@@ -97,112 +97,190 @@ func (b boolBuilder) Bool() pgtype.Bool {
 	return pgtype.Bool{Bool: b.input.value, Valid: true}
 }
 
+// intPresent reports whether an integer builder should produce a valid
+// (non-NULL) value. It is false when the input is absent (e.g. a nil pointer)
+// or when ZeroIsNull() was requested and the value is zero.
+func intPresent(value int64, present, zeroIsNull bool) bool {
+	if !present {
+		return false
+	}
+	if zeroIsNull && value == 0 {
+		return false
+	}
+	return true
+}
+
 type int8Builder struct {
-	input inputValue[int8]
+	input      inputValue[int8]
+	zeroIsNull bool
+}
+
+// ZeroIsNull makes the resulting pgtype value NULL when the input integer is 0.
+func (b int8Builder) ZeroIsNull() int8Builder {
+	b.zeroIsNull = true
+	return b
+}
+
+func (b int8Builder) present() bool {
+	return intPresent(int64(b.input.value), b.input.present, b.zeroIsNull)
 }
 
 func (b int8Builder) Int2() pgtype.Int2 {
-	return int2TruncatedValue(int64(b.input.value), b.input.present)
+	return int2TruncatedValue(int64(b.input.value), b.present())
 }
 
 func (b int8Builder) Int4() pgtype.Int4 {
-	return int4TruncatedValue(int64(b.input.value), b.input.present)
+	return int4TruncatedValue(int64(b.input.value), b.present())
 }
 
 func (b int8Builder) Int8() pgtype.Int8 {
-	return int8Value(int64(b.input.value), b.input.present)
+	return int8Value(int64(b.input.value), b.present())
 }
 
 type int16Builder struct {
-	input inputValue[int16]
+	input      inputValue[int16]
+	zeroIsNull bool
+}
+
+// ZeroIsNull makes the resulting pgtype value NULL when the input integer is 0.
+func (b int16Builder) ZeroIsNull() int16Builder {
+	b.zeroIsNull = true
+	return b
+}
+
+func (b int16Builder) present() bool {
+	return intPresent(int64(b.input.value), b.input.present, b.zeroIsNull)
 }
 
 func (b int16Builder) Int2() pgtype.Int2 {
-	return int2TruncatedValue(int64(b.input.value), b.input.present)
+	return int2TruncatedValue(int64(b.input.value), b.present())
 }
 
 func (b int16Builder) Int4() pgtype.Int4 {
-	return int4TruncatedValue(int64(b.input.value), b.input.present)
+	return int4TruncatedValue(int64(b.input.value), b.present())
 }
 
 func (b int16Builder) Int8() pgtype.Int8 {
-	return int8Value(int64(b.input.value), b.input.present)
+	return int8Value(int64(b.input.value), b.present())
 }
 
 type int32Builder struct {
-	input inputValue[int32]
+	input      inputValue[int32]
+	zeroIsNull bool
+}
+
+// ZeroIsNull makes the resulting pgtype value NULL when the input integer is 0.
+func (b int32Builder) ZeroIsNull() int32Builder {
+	b.zeroIsNull = true
+	return b
+}
+
+func (b int32Builder) present() bool {
+	return intPresent(int64(b.input.value), b.input.present, b.zeroIsNull)
 }
 
 func (b int32Builder) Int2() pgtype.Int2 {
-	return int2TruncatedValue(int64(b.input.value), b.input.present)
+	return int2TruncatedValue(int64(b.input.value), b.present())
 }
 
 func (b int32Builder) TryInt2() (pgtype.Int2, error) {
-	return int2Value(int64(b.input.value), b.input.present)
+	return int2Value(int64(b.input.value), b.present())
 }
 
 func (b int32Builder) Int4() pgtype.Int4 {
-	return int4TruncatedValue(int64(b.input.value), b.input.present)
+	return int4TruncatedValue(int64(b.input.value), b.present())
 }
 
 func (b int32Builder) Int8() pgtype.Int8 {
-	return int8Value(int64(b.input.value), b.input.present)
+	return int8Value(int64(b.input.value), b.present())
 }
 
 type int64Builder struct {
-	input inputValue[int64]
+	input      inputValue[int64]
+	zeroIsNull bool
+}
+
+// ZeroIsNull makes the resulting pgtype value NULL when the input integer is 0.
+func (b int64Builder) ZeroIsNull() int64Builder {
+	b.zeroIsNull = true
+	return b
+}
+
+func (b int64Builder) present() bool {
+	return intPresent(b.input.value, b.input.present, b.zeroIsNull)
 }
 
 func (b int64Builder) Int2() pgtype.Int2 {
-	return int2TruncatedValue(b.input.value, b.input.present)
+	return int2TruncatedValue(b.input.value, b.present())
 }
 
 func (b int64Builder) TryInt2() (pgtype.Int2, error) {
-	return int2Value(b.input.value, b.input.present)
+	return int2Value(b.input.value, b.present())
 }
 
 func (b int64Builder) Int4() pgtype.Int4 {
-	return int4TruncatedValue(b.input.value, b.input.present)
+	return int4TruncatedValue(b.input.value, b.present())
 }
 
 func (b int64Builder) TryInt4() (pgtype.Int4, error) {
-	return int4Value(b.input.value, b.input.present)
+	return int4Value(b.input.value, b.present())
 }
 
 func (b int64Builder) Int8() pgtype.Int8 {
-	return int8Value(b.input.value, b.input.present)
+	return int8Value(b.input.value, b.present())
 }
 
 type intBuilder struct {
-	input inputValue[int]
+	input      inputValue[int]
+	zeroIsNull bool
+}
+
+// ZeroIsNull makes the resulting pgtype value NULL when the input integer is 0.
+func (b intBuilder) ZeroIsNull() intBuilder {
+	b.zeroIsNull = true
+	return b
+}
+
+func (b intBuilder) present() bool {
+	return intPresent(int64(b.input.value), b.input.present, b.zeroIsNull)
 }
 
 func (b intBuilder) Int2() pgtype.Int2 {
-	return int2TruncatedValue(int64(b.input.value), b.input.present)
+	return int2TruncatedValue(int64(b.input.value), b.present())
 }
 
 func (b intBuilder) TryInt2() (pgtype.Int2, error) {
-	return int2Value(int64(b.input.value), b.input.present)
+	return int2Value(int64(b.input.value), b.present())
 }
 
 func (b intBuilder) Int4() pgtype.Int4 {
-	return int4TruncatedValue(int64(b.input.value), b.input.present)
+	return int4TruncatedValue(int64(b.input.value), b.present())
 }
 
 func (b intBuilder) TryInt4() (pgtype.Int4, error) {
-	return int4Value(int64(b.input.value), b.input.present)
+	return int4Value(int64(b.input.value), b.present())
 }
 
 func (b intBuilder) Int8() pgtype.Int8 {
-	return int8Value(int64(b.input.value), b.input.present)
+	return int8Value(int64(b.input.value), b.present())
 }
 
 type float64Builder struct {
-	input inputValue[float64]
+	input      inputValue[float64]
+	zeroIsNull bool
+}
+
+// ZeroIsNull makes the resulting pgtype value NULL when the input float is 0.
+func (b float64Builder) ZeroIsNull() float64Builder {
+	b.zeroIsNull = true
+	return b
 }
 
 func (b float64Builder) Float8() pgtype.Float8 {
 	if !b.input.present {
+		return pgtype.Float8{}
+	}
+	if b.zeroIsNull && b.input.value == 0 {
 		return pgtype.Float8{}
 	}
 	return pgtype.Float8{Float64: b.input.value, Valid: true}

--- a/pgconv/pgencode/pgencode_test.go
+++ b/pgconv/pgencode/pgencode_test.go
@@ -80,12 +80,81 @@ func TestIntegers(t *testing.T) {
 	}
 }
 
+func TestIntegersZeroIsNull(t *testing.T) {
+	// Non-zero values stay valid and carry the value through every output width.
+	if got := pgencode.Int64(5).ZeroIsNull().Int8(); !got.Valid || got.Int64 != 5 {
+		t.Fatalf("Int64(5).ZeroIsNull().Int8() = %#v", got)
+	}
+	if got := pgencode.Int64(5).ZeroIsNull().Int4(); !got.Valid || got.Int32 != 5 {
+		t.Fatalf("Int64(5).ZeroIsNull().Int4() = %#v", got)
+	}
+	if got := pgencode.Int64(5).ZeroIsNull().Int2(); !got.Valid || got.Int16 != 5 {
+		t.Fatalf("Int64(5).ZeroIsNull().Int2() = %#v", got)
+	}
+
+	// Zero values become NULL at every output width.
+	if got := pgencode.Int64(0).ZeroIsNull().Int8(); got.Valid {
+		t.Fatalf("Int64(0).ZeroIsNull().Int8() = %#v", got)
+	}
+	if got := pgencode.Int64(0).ZeroIsNull().Int4(); got.Valid {
+		t.Fatalf("Int64(0).ZeroIsNull().Int4() = %#v", got)
+	}
+	if got := pgencode.Int64(0).ZeroIsNull().Int2(); got.Valid {
+		t.Fatalf("Int64(0).ZeroIsNull().Int2() = %#v", got)
+	}
+
+	// Without ZeroIsNull, zero remains a valid value.
+	if got := pgencode.Int64(0).Int8(); !got.Valid || got.Int64 != 0 {
+		t.Fatalf("Int64(0).Int8() = %#v", got)
+	}
+
+	// Every integer constructor exposes ZeroIsNull with the same semantics.
+	if got := pgencode.Int8(0).ZeroIsNull().Int8(); got.Valid {
+		t.Fatalf("Int8(0).ZeroIsNull().Int8() = %#v", got)
+	}
+	if got := pgencode.Int8(3).ZeroIsNull().Int8(); !got.Valid || got.Int64 != 3 {
+		t.Fatalf("Int8(3).ZeroIsNull().Int8() = %#v", got)
+	}
+	if got := pgencode.Int16(0).ZeroIsNull().Int4(); got.Valid {
+		t.Fatalf("Int16(0).ZeroIsNull().Int4() = %#v", got)
+	}
+	if got := pgencode.Int16(4).ZeroIsNull().Int4(); !got.Valid || got.Int32 != 4 {
+		t.Fatalf("Int16(4).ZeroIsNull().Int4() = %#v", got)
+	}
+	if got := pgencode.Int32(0).ZeroIsNull().Int4(); got.Valid {
+		t.Fatalf("Int32(0).ZeroIsNull().Int4() = %#v", got)
+	}
+	if got := pgencode.Int(0).ZeroIsNull().Int8(); got.Valid {
+		t.Fatalf("Int(0).ZeroIsNull().Int8() = %#v", got)
+	}
+	if got := pgencode.Int(6).ZeroIsNull().Int8(); !got.Valid || got.Int64 != 6 {
+		t.Fatalf("Int(6).ZeroIsNull().Int8() = %#v", got)
+	}
+
+	// ZeroIsNull composes with the checked (Try*) outputs: zero -> NULL, no error.
+	if got, err := pgencode.Int32(0).ZeroIsNull().TryInt2(); err != nil || got.Valid {
+		t.Fatalf("Int32(0).ZeroIsNull().TryInt2() = %#v, err=%v", got, err)
+	}
+	if got, err := pgencode.Int64(7).ZeroIsNull().TryInt4(); err != nil || !got.Valid || got.Int32 != 7 {
+		t.Fatalf("Int64(7).ZeroIsNull().TryInt4() = %#v, err=%v", got, err)
+	}
+}
+
 func TestFloat64(t *testing.T) {
 	if got := pgencode.Float64(1.5).Float8(); !got.Valid || got.Float64 != 1.5 {
 		t.Fatalf("Float64().Float8() = %#v", got)
 	}
 	if got := pgencode.Float64Ptr((*float64)(nil)).Float8(); got.Valid {
 		t.Fatalf("Float64Ptr(nil).Float8() = %#v", got)
+	}
+	if got := pgencode.Float64(0).ZeroIsNull().Float8(); got.Valid {
+		t.Fatalf("Float64(0).ZeroIsNull().Float8() = %#v", got)
+	}
+	if got := pgencode.Float64(2.5).ZeroIsNull().Float8(); !got.Valid || got.Float64 != 2.5 {
+		t.Fatalf("Float64(2.5).ZeroIsNull().Float8() = %#v", got)
+	}
+	if got := pgencode.Float64(0).Float8(); !got.Valid || got.Float64 != 0 {
+		t.Fatalf("Float64(0).Float8() = %#v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Two related changes to the `pgconv` module:

1. **New `ZeroIsNull()` encoders** on the integer and float `pgencode` builders, closing a gap where "conditional-Valid" pgtype literals had no fluent-builder equivalent.
2. **`pgconvlint` now suggests them** — a `pgtype.IntN{IntX: v, Valid: v != 0}` / `pgtype.Float8{Float64: v, Valid: v != 0}` composite literal is reported (and auto-fixed) as `pgencode.Fn(v).ZeroIsNull().Method()`.

### 1. `pgencode` — `ZeroIsNull()` on int/float builders

Before this, only these null-collapsing modifiers existed: `stringBuilder.EmptyIsNull()`, `timeBuilder.ZeroIsNull()`, `uuidBuilder.NilIsNull()`. There was no way to express the very common:

```go
pgtype.Int8{Int64: x, Valid: x != 0}
```

Now:

```go
pgencode.Int64(x).ZeroIsNull().Int8()   // NULL when x == 0, else {Int64: x, Valid: true}
```

Added `ZeroIsNull()` to every integer builder (`int8Builder`, `int16Builder`, `int32Builder`, `int64Builder`, `intBuilder`) and to `float64Builder`. Semantics: the resulting `pgtype.IntN` / `pgtype.Float8` is `Valid:false` when the input value is 0, otherwise `Valid:true` with the value. It composes with all output widths (`.Int2()`/`.Int4()`/`.Int8()`, `.Float8()`) and with the checked `TryInt2()`/`TryInt4()` outputs (zero → NULL, no overflow error). `Ptr` constructors are unchanged — they already collapse nil → NULL.

There is no `safeIntBuilder` in the codebase, so nothing was added there.

### 2. `pgconvlint` — suggest the new helper

The analyzer's encode rule already emitted `.EmptyIsNull()` for `Valid: s != ""` on `Text`. This threads the same mechanism through the int/float rules:

- `pgtype.IntN{IntX: v, Valid: v != 0}` (or `0 != v`) → `pgencode.IntXX(v).ZeroIsNull().IntN()`
- `pgtype.Float8{Float64: v, Valid: v != 0}` (or `0.0`) → `pgencode.Float64(v).ZeroIsNull().Float8()`
- `pgtype.Text{String: s, Valid: s != ""}` → `.EmptyIsNull().Text()` (unchanged, kept)

Implemented by adding a `zeroIsNull` flag to `pgtypeRule` (set on `Int2`/`Int4`/`Int8`/`Float8`) and an `isNonZeroCheck` predicate, consulted in both `encodeSuggestion` (diagnostic text) and `encodeReplacement` (suggested fix). Added testdata + golden coverage in `pgconvlint/testdata/src/a`.

### Verification

`go test ./...` and `go vet ./...` pass inside the `pgconv` module; `cmd/pgconvlint` still builds.

## Backend follow-up (separate PR, not in this change)

The ditto-assistant/backend repo will (separately):
- Bump the go-kit `pgconv` module version it depends on.
- Replace its local copy of the analyzer + `internal/lintignore` (under `pkg/analyzers/pgconvlint/` and `pkg/analyzers/internal/lintignore/`) with imports of `github.com/omniaura/go-kit/pgconv/pgconvlint`, and point `cmd/dittolint` at the go-kit analyzer. (Note: the go-kit copy is already ahead of the backend copy — it carries `analysis.SuggestedFix` support the backend version lacks.)
- Simplify the intermediate-variable workarounds that motivated this (e.g. the `keyID *int64` dance) using `pgencode.Int64(x).ZeroIsNull().Int8()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
