### PR TITLE
feat(pgconv): TrimSpace/NonPositiveIsNull encoders + CoalesceText decoder + pgconvlint suggestions

### DIFF
--- a/pgconv/pgconvlint/analyzer.go
+++ b/pgconv/pgconvlint/analyzer.go
@@ -48,7 +48,8 @@ type pgtypeRule struct {
 	// zeroIsNull is true when the encode builder exposes a ZeroIsNull() method,
 	// i.e. a `Valid: v != 0` composite literal can be rewritten as
 	// pgencode.Fn(v).ZeroIsNull().Method(). Applies to the integer and float
-	// builders.
+	// builders. The same builders also expose NonPositiveIsNull() for a
+	// `Valid: v > 0` composite literal (NULL when v <= 0).
 	zeroIsNull bool
 }
 
@@ -511,12 +512,21 @@ func encodeSuggestion(pass *analysis.Pass, rule pgtypeRule, value, valid ast.Exp
 		return fmt.Sprintf("pgencode.%sPtr(...).%s()", rule.encodeFunc, rule.encodeMethod)
 	}
 
-	if rule.encodeFunc == "String" && isNonEmptyStringCheck(valid, value, pass.Fset) {
-		return fmt.Sprintf("pgencode.%s(...).EmptyIsNull().%s()", rule.encodeFunc, rule.encodeMethod)
+	if rule.encodeFunc == "String" {
+		if _, ok := trimSpaceArg(value); ok && isNonEmptyStringCheck(valid, value, pass.Fset) {
+			return fmt.Sprintf("pgencode.%s(...).TrimSpace().EmptyIsNull().%s()", rule.encodeFunc, rule.encodeMethod)
+		}
+		if isNonEmptyStringCheck(valid, value, pass.Fset) {
+			return fmt.Sprintf("pgencode.%s(...).EmptyIsNull().%s()", rule.encodeFunc, rule.encodeMethod)
+		}
 	}
 
 	if rule.zeroIsNull && isNonZeroCheck(valid, value, pass.Fset) {
 		return fmt.Sprintf("pgencode.%s(...).ZeroIsNull().%s()", rule.encodeFunc, rule.encodeMethod)
+	}
+
+	if rule.zeroIsNull && isPositiveCheck(valid, value, pass.Fset) {
+		return fmt.Sprintf("pgencode.%s(...).NonPositiveIsNull().%s()", rule.encodeFunc, rule.encodeMethod)
 	}
 
 	return fmt.Sprintf("pgencode.%s(...).%s()", rule.encodeFunc, rule.encodeMethod)
@@ -538,15 +548,21 @@ func (r reporter) encodeReplacement(rule pgtypeRule, typeName, valueField string
 	arg := renderNode(r.pass.Fset, value)
 	chain := ""
 	ptr := dereferencedExpr(value)
+	trimmed, isTrim := trimSpaceArg(value)
 	switch {
 	case isTrue(valid):
 	case ptr != nil && isNotNilCheck(valid, ptr, r.pass.Fset):
 		fn += "Ptr"
 		arg = renderNode(r.pass.Fset, ptr)
+	case rule.encodeFunc == "String" && isTrim && isNonEmptyStringCheck(valid, value, r.pass.Fset):
+		arg = renderNode(r.pass.Fset, trimmed)
+		chain = ".TrimSpace().EmptyIsNull()"
 	case rule.encodeFunc == "String" && isNonEmptyStringCheck(valid, value, r.pass.Fset):
 		chain = ".EmptyIsNull()"
 	case rule.zeroIsNull && isNonZeroCheck(valid, value, r.pass.Fset):
 		chain = ".ZeroIsNull()"
+	case rule.zeroIsNull && isPositiveCheck(valid, value, r.pass.Fset):
+		chain = ".NonPositiveIsNull()"
 	default:
 		return encodeReplacement{}, false
 	}
@@ -912,6 +928,24 @@ func dereferencedExpr(expr ast.Expr) ast.Expr {
 	return star.X
 }
 
+// trimSpaceArg returns the single argument x when expr is a `strings.TrimSpace(x)`
+// call, so the constructor can be built over x with a .TrimSpace() step.
+func trimSpaceArg(expr ast.Expr) (ast.Expr, bool) {
+	call, ok := unparen(expr).(*ast.CallExpr)
+	if !ok || len(call.Args) != 1 {
+		return nil, false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "TrimSpace" {
+		return nil, false
+	}
+	pkg, ok := unparen(sel.X).(*ast.Ident)
+	if !ok || pkg.Name != "strings" {
+		return nil, false
+	}
+	return call.Args[0], true
+}
+
 func isNonEmptyStringCheck(expr, value ast.Expr, fset *token.FileSet) bool {
 	bin, ok := unparen(expr).(*ast.BinaryExpr)
 	if !ok || bin.Op != token.NEQ {
@@ -928,6 +962,23 @@ func isNonZeroCheck(expr, value ast.Expr, fset *token.FileSet) bool {
 	}
 	return (sameExpr(bin.X, value, fset) && isZeroLiteral(bin.Y)) ||
 		(sameExpr(bin.Y, value, fset) && isZeroLiteral(bin.X))
+}
+
+// isPositiveCheck reports whether expr is a `value > 0` / `0 < value` comparison,
+// i.e. the composite literal is NULL when value <= 0 (maps to NonPositiveIsNull()).
+func isPositiveCheck(expr, value ast.Expr, fset *token.FileSet) bool {
+	bin, ok := unparen(expr).(*ast.BinaryExpr)
+	if !ok {
+		return false
+	}
+	switch bin.Op {
+	case token.GTR: // value > 0
+		return sameExpr(bin.X, value, fset) && isZeroLiteral(bin.Y)
+	case token.LSS: // 0 < value
+		return sameExpr(bin.Y, value, fset) && isZeroLiteral(bin.X)
+	default:
+		return false
+	}
 }
 
 func isZeroLiteral(expr ast.Expr) bool {

--- a/pgconv/pgconvlint/testdata/src/a/a.go
+++ b/pgconv/pgconvlint/testdata/src/a/a.go
@@ -1,6 +1,7 @@
 package a
 
 import (
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -9,18 +10,21 @@ import (
 )
 
 func encode(s string, p *string, b bool, n int64, f float64, tm time.Time, id [16]byte) {
-	_ = pgtype.Text{String: s, Valid: true}        // want "manual pgtype.Text encode; use pgencode.String"
-	_ = pgtype.Text{String: s, Valid: s != ""}     // want "manual pgtype.Text encode; use pgencode.String\\(\\.\\.\\.\\).EmptyIsNull\\(\\).Text\\(\\)"
-	_ = pgtype.Text{String: *p, Valid: p != nil}   // want "manual pgtype.Text encode; use pgencode.StringPtr"
-	_ = pgtype.Bool{Bool: b, Valid: true}          // want "manual pgtype.Bool encode; use pgencode.Bool"
-	_ = pgtype.Int8{Int64: n, Valid: true}         // want "manual pgtype.Int8 encode; use pgencode.Int64"
-	_ = pgtype.Int8{Int64: n, Valid: n != 0}       // want "manual pgtype.Int8 encode; use pgencode.Int64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Int8\\(\\)"
-	_ = pgtype.Int8{Int64: n, Valid: 0 != n}       // want "manual pgtype.Int8 encode; use pgencode.Int64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Int8\\(\\)"
-	_ = pgtype.Float8{Float64: f, Valid: f != 0}   // want "manual pgtype.Float8 encode; use pgencode.Float64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Float8\\(\\)"
-	_ = pgtype.Float8{Float64: f, Valid: f != 0.0} // want "manual pgtype.Float8 encode; use pgencode.Float64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Float8\\(\\)"
-	_ = pgtype.Timestamptz{Time: tm, Valid: true}  // want "manual pgtype.Timestamptz encode; use pgencode.Time"
-	_ = pgtype.UUID{Bytes: id, Valid: true}        // want "manual pgtype.UUID encode; use pgencode.UUID"
-	_ = pgtype.Text{String: s}                     // want "manual pgtype.Text encode; use pgencode.String"
+	_ = pgtype.Text{String: s, Valid: true}                                          // want "manual pgtype.Text encode; use pgencode.String"
+	_ = pgtype.Text{String: s, Valid: s != ""}                                       // want "manual pgtype.Text encode; use pgencode.String\\(\\.\\.\\.\\).EmptyIsNull\\(\\).Text\\(\\)"
+	_ = pgtype.Text{String: *p, Valid: p != nil}                                     // want "manual pgtype.Text encode; use pgencode.StringPtr"
+	_ = pgtype.Text{String: strings.TrimSpace(s), Valid: strings.TrimSpace(s) != ""} // want "manual pgtype.Text encode; use pgencode.String\\(\\.\\.\\.\\).TrimSpace\\(\\).EmptyIsNull\\(\\).Text\\(\\)"
+	_ = pgtype.Bool{Bool: b, Valid: true}                                            // want "manual pgtype.Bool encode; use pgencode.Bool"
+	_ = pgtype.Int8{Int64: n, Valid: true}                                           // want "manual pgtype.Int8 encode; use pgencode.Int64"
+	_ = pgtype.Int8{Int64: n, Valid: n != 0}                                         // want "manual pgtype.Int8 encode; use pgencode.Int64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Int8\\(\\)"
+	_ = pgtype.Int8{Int64: n, Valid: 0 != n}                                         // want "manual pgtype.Int8 encode; use pgencode.Int64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Int8\\(\\)"
+	_ = pgtype.Int8{Int64: n, Valid: n > 0}                                          // want "manual pgtype.Int8 encode; use pgencode.Int64\\(\\.\\.\\.\\).NonPositiveIsNull\\(\\).Int8\\(\\)"
+	_ = pgtype.Int8{Int64: n, Valid: 0 < n}                                          // want "manual pgtype.Int8 encode; use pgencode.Int64\\(\\.\\.\\.\\).NonPositiveIsNull\\(\\).Int8\\(\\)"
+	_ = pgtype.Float8{Float64: f, Valid: f != 0}                                     // want "manual pgtype.Float8 encode; use pgencode.Float64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Float8\\(\\)"
+	_ = pgtype.Float8{Float64: f, Valid: f != 0.0}                                   // want "manual pgtype.Float8 encode; use pgencode.Float64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Float8\\(\\)"
+	_ = pgtype.Timestamptz{Time: tm, Valid: true}                                    // want "manual pgtype.Timestamptz encode; use pgencode.Time"
+	_ = pgtype.UUID{Bytes: id, Valid: true}                                          // want "manual pgtype.UUID encode; use pgencode.UUID"
+	_ = pgtype.Text{String: s}                                                       // want "manual pgtype.Text encode; use pgencode.String"
 	//lint:ignore pgconvlint legacy test fixture
 	_ = pgtype.Text{String: s, Valid: true}
 	_ = pgtype.Text{}             // zero/null literals are allowed

--- a/pgconv/pgconvlint/testdata/src/a/a.go.golden
+++ b/pgconv/pgconvlint/testdata/src/a/a.go.golden
@@ -9,18 +9,21 @@ import (
 )
 
 func encode(s string, p *string, b bool, n int64, f float64, tm time.Time, id [16]byte) {
-	_ = pgencode.String(s).Text()                        // want "manual pgtype.Text encode; use pgencode.String"
-	_ = pgencode.String(s).EmptyIsNull().Text()          // want "manual pgtype.Text encode; use pgencode.String\\(\\.\\.\\.\\).EmptyIsNull\\(\\).Text\\(\\)"
-	_ = pgencode.StringPtr(p).Text()                     // want "manual pgtype.Text encode; use pgencode.StringPtr"
-	_ = pgencode.Bool(b).Bool()                          // want "manual pgtype.Bool encode; use pgencode.Bool"
-	_ = pgencode.Int64(n).Int8()                         // want "manual pgtype.Int8 encode; use pgencode.Int64"
-	_ = pgencode.Int64(n).ZeroIsNull().Int8()            // want "manual pgtype.Int8 encode; use pgencode.Int64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Int8\\(\\)"
-	_ = pgencode.Int64(n).ZeroIsNull().Int8()            // want "manual pgtype.Int8 encode; use pgencode.Int64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Int8\\(\\)"
-	_ = pgencode.Float64(f).ZeroIsNull().Float8()        // want "manual pgtype.Float8 encode; use pgencode.Float64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Float8\\(\\)"
-	_ = pgencode.Float64(f).ZeroIsNull().Float8()        // want "manual pgtype.Float8 encode; use pgencode.Float64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Float8\\(\\)"
-	_ = pgencode.Time(tm).Timestamptz()                  // want "manual pgtype.Timestamptz encode; use pgencode.Time"
-	_ = pgencode.UUID(id).UUID()                         // want "manual pgtype.UUID encode; use pgencode.UUID"
-	_ = pgtype.Text{String: s}                           // want "manual pgtype.Text encode; use pgencode.String"
+	_ = pgencode.String(s).Text()                           // want "manual pgtype.Text encode; use pgencode.String"
+	_ = pgencode.String(s).EmptyIsNull().Text()             // want "manual pgtype.Text encode; use pgencode.String\\(\\.\\.\\.\\).EmptyIsNull\\(\\).Text\\(\\)"
+	_ = pgencode.StringPtr(p).Text()                        // want "manual pgtype.Text encode; use pgencode.StringPtr"
+	_ = pgencode.String(s).TrimSpace().EmptyIsNull().Text() // want "manual pgtype.Text encode; use pgencode.String\\(\\.\\.\\.\\).TrimSpace\\(\\).EmptyIsNull\\(\\).Text\\(\\)"
+	_ = pgencode.Bool(b).Bool()                             // want "manual pgtype.Bool encode; use pgencode.Bool"
+	_ = pgencode.Int64(n).Int8()                            // want "manual pgtype.Int8 encode; use pgencode.Int64"
+	_ = pgencode.Int64(n).ZeroIsNull().Int8()               // want "manual pgtype.Int8 encode; use pgencode.Int64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Int8\\(\\)"
+	_ = pgencode.Int64(n).ZeroIsNull().Int8()               // want "manual pgtype.Int8 encode; use pgencode.Int64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Int8\\(\\)"
+	_ = pgencode.Int64(n).NonPositiveIsNull().Int8()        // want "manual pgtype.Int8 encode; use pgencode.Int64\\(\\.\\.\\.\\).NonPositiveIsNull\\(\\).Int8\\(\\)"
+	_ = pgencode.Int64(n).NonPositiveIsNull().Int8()        // want "manual pgtype.Int8 encode; use pgencode.Int64\\(\\.\\.\\.\\).NonPositiveIsNull\\(\\).Int8\\(\\)"
+	_ = pgencode.Float64(f).ZeroIsNull().Float8()           // want "manual pgtype.Float8 encode; use pgencode.Float64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Float8\\(\\)"
+	_ = pgencode.Float64(f).ZeroIsNull().Float8()           // want "manual pgtype.Float8 encode; use pgencode.Float64\\(\\.\\.\\.\\).ZeroIsNull\\(\\).Float8\\(\\)"
+	_ = pgencode.Time(tm).Timestamptz()                     // want "manual pgtype.Timestamptz encode; use pgencode.Time"
+	_ = pgencode.UUID(id).UUID()                            // want "manual pgtype.UUID encode; use pgencode.UUID"
+	_ = pgtype.Text{String: s}                              // want "manual pgtype.Text encode; use pgencode.String"
 	//lint:ignore pgconvlint legacy test fixture
 	_ = pgtype.Text{String: s, Valid: true}
 	_ = pgtype.Text{}             // zero/null literals are allowed

--- a/pgconv/pgconvlint/testdata/src/github.com/omniaura/go-kit/pgconv/pgencode/pgencode.go
+++ b/pgconv/pgconvlint/testdata/src/github.com/omniaura/go-kit/pgconv/pgencode/pgencode.go
@@ -25,6 +25,10 @@ func (b textBuilder) EmptyIsNull() textBuilder {
 	return b
 }
 
+func (b textBuilder) TrimSpace() textBuilder {
+	return b
+}
+
 func (b textBuilder) Text() pgtype.Text {
 	return pgtype.Text{String: b.value, Valid: true}
 }
@@ -50,6 +54,10 @@ func Int64(value int64) int64Builder {
 }
 
 func (b int64Builder) ZeroIsNull() int64Builder {
+	return b
+}
+
+func (b int64Builder) NonPositiveIsNull() int64Builder {
 	return b
 }
 

--- a/pgconv/pgdecode/pgdecode.go
+++ b/pgconv/pgdecode/pgdecode.go
@@ -658,6 +658,23 @@ func Text(value pgtype.Text) textBuilder {
 	return textBuilder{value: newNullableValue(value.Valid, value.String)}
 }
 
+// CoalesceText returns a textBuilder over the first argument that decodes to a
+// non-empty string. "Non-empty" is stronger than Valid: a value that is Valid
+// but whose String is "" is skipped. If every argument decodes to "", the
+// builder resolves as valid over that empty string, so .Value() returns "" and
+// .Ptr()/.Fill() still yield the empty value (they do not report NULL). Pass the
+// most-preferred value first, e.g.
+// pgdecode.CoalesceText(description, title).Value() prefers a non-empty
+// description and otherwise falls back to title.
+func CoalesceText(values ...pgtype.Text) textBuilder {
+	for _, value := range values {
+		if value.Valid && value.String != "" {
+			return textBuilder{value: newNullableValue(true, value.String)}
+		}
+	}
+	return textBuilder{value: newNullableValue(true, "")}
+}
+
 func Bool(value pgtype.Bool) boolBuilder {
 	return boolBuilder{value: newNullableValue(value.Valid, value.Bool)}
 }

--- a/pgconv/pgdecode/pgdecode_test.go
+++ b/pgconv/pgdecode/pgdecode_test.go
@@ -48,6 +48,55 @@ func TestText(t *testing.T) {
 	}
 }
 
+func TestCoalesceText(t *testing.T) {
+	title := pgtype.Text{String: "title", Valid: true}
+	description := pgtype.Text{String: "description", Valid: true}
+	emptyValid := pgtype.Text{String: "", Valid: true}
+	null := pgtype.Text{}
+
+	// First non-empty wins: a non-empty description is preferred over title.
+	if got := pgdecode.CoalesceText(description, title).Value(); got != "description" {
+		t.Fatalf("CoalesceText(description, title).Value() = %q", got)
+	}
+	// Empty (even if Valid) is skipped, falling through to the next non-empty.
+	if got := pgdecode.CoalesceText(emptyValid, title).Value(); got != "title" {
+		t.Fatalf("CoalesceText(emptyValid, title).Value() = %q", got)
+	}
+	// NULL is skipped too.
+	if got := pgdecode.CoalesceText(null, title).Value(); got != "title" {
+		t.Fatalf("CoalesceText(null, title).Value() = %q", got)
+	}
+
+	// All-empty resolves to "" and remains non-NULL (Ptr/Fill still yield "").
+	allEmpty := pgdecode.CoalesceText(null, emptyValid)
+	if got := allEmpty.Value(); got != "" {
+		t.Fatalf("CoalesceText(all empty).Value() = %q", got)
+	}
+	if ptr := allEmpty.Ptr(); ptr == nil || *ptr != "" {
+		t.Fatalf("CoalesceText(all empty).Ptr() = %#v", ptr)
+	}
+	filled := "seed"
+	allEmpty.Fill(&filled)
+	if filled != "" {
+		t.Fatalf("CoalesceText(all empty).Fill() = %q", filled)
+	}
+
+	// No args behaves like all-empty.
+	if got := pgdecode.CoalesceText().Value(); got != "" {
+		t.Fatalf("CoalesceText().Value() = %q", got)
+	}
+
+	// Ptr/Fill on a match.
+	if ptr := pgdecode.CoalesceText(description, title).Ptr(); ptr == nil || *ptr != "description" {
+		t.Fatalf("CoalesceText(description, title).Ptr() = %#v", ptr)
+	}
+	dst := "seed"
+	pgdecode.CoalesceText(null, title).Fill(&dst)
+	if dst != "title" {
+		t.Fatalf("CoalesceText(null, title).Fill() = %q", dst)
+	}
+}
+
 func TestBoolAndIntegers(t *testing.T) {
 	if got := pgdecode.Bool(pgtype.Bool{Bool: true, Valid: true}).Value(); !got {
 		t.Fatalf("Bool.Value() = %v", got)

--- a/pgconv/pgencode/pgencode.go
+++ b/pgconv/pgencode/pgencode.go
@@ -3,6 +3,7 @@ package pgencode
 import (
 	"fmt"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -69,6 +70,7 @@ func int4TruncatedValue(value int64, present bool) pgtype.Int4 {
 type stringBuilder struct {
 	input       inputValue[string]
 	emptyIsNull bool
+	trimSpace   bool
 }
 
 func (b stringBuilder) EmptyIsNull() stringBuilder {
@@ -76,14 +78,31 @@ func (b stringBuilder) EmptyIsNull() stringBuilder {
 	return b
 }
 
+// TrimSpace trims leading and trailing whitespace (via strings.TrimSpace) from
+// the input before the value and validity are computed. It composes with
+// EmptyIsNull() in either order, so pgencode.String(v).TrimSpace().EmptyIsNull().Text()
+// yields a NULL pgtype.Text when v is empty or all-whitespace.
+func (b stringBuilder) TrimSpace() stringBuilder {
+	b.trimSpace = true
+	return b
+}
+
+func (b stringBuilder) resolved() string {
+	if b.trimSpace {
+		return strings.TrimSpace(b.input.value)
+	}
+	return b.input.value
+}
+
 func (b stringBuilder) Text() pgtype.Text {
 	if !b.input.present {
 		return pgtype.Text{}
 	}
-	if b.emptyIsNull && b.input.value == "" {
+	value := b.resolved()
+	if b.emptyIsNull && value == "" {
 		return pgtype.Text{}
 	}
-	return pgtype.Text{String: b.input.value, Valid: true}
+	return pgtype.Text{String: value, Valid: true}
 }
 
 type boolBuilder struct {
@@ -97,32 +116,54 @@ func (b boolBuilder) Bool() pgtype.Bool {
 	return pgtype.Bool{Bool: b.input.value, Valid: true}
 }
 
+// intNullMode records the optional NULL-selection modifier requested on an
+// integer builder. Zero value (intNullNone) means "only a nil pointer is NULL".
+type intNullMode uint8
+
+const (
+	intNullNone        intNullMode = iota // no modifier
+	intNullZero                           // ZeroIsNull(): NULL when value == 0
+	intNullNonPositive                    // NonPositiveIsNull(): NULL when value <= 0
+)
+
 // intPresent reports whether an integer builder should produce a valid
 // (non-NULL) value. It is false when the input is absent (e.g. a nil pointer)
-// or when ZeroIsNull() was requested and the value is zero.
-func intPresent(value int64, present, zeroIsNull bool) bool {
+// or when the requested nullMode selects the value as NULL: ZeroIsNull when the
+// value is zero, NonPositiveIsNull when the value is <= 0.
+func intPresent(value int64, present bool, nullMode intNullMode) bool {
 	if !present {
 		return false
 	}
-	if zeroIsNull && value == 0 {
-		return false
+	switch nullMode {
+	case intNullZero:
+		return value != 0
+	case intNullNonPositive:
+		return value > 0
+	default:
+		return true
 	}
-	return true
 }
 
 type int8Builder struct {
-	input      inputValue[int8]
-	zeroIsNull bool
+	input    inputValue[int8]
+	nullMode intNullMode
 }
 
 // ZeroIsNull makes the resulting pgtype value NULL when the input integer is 0.
 func (b int8Builder) ZeroIsNull() int8Builder {
-	b.zeroIsNull = true
+	b.nullMode = intNullZero
+	return b
+}
+
+// NonPositiveIsNull makes the resulting pgtype value NULL when the input integer
+// is <= 0 (zero or negative).
+func (b int8Builder) NonPositiveIsNull() int8Builder {
+	b.nullMode = intNullNonPositive
 	return b
 }
 
 func (b int8Builder) present() bool {
-	return intPresent(int64(b.input.value), b.input.present, b.zeroIsNull)
+	return intPresent(int64(b.input.value), b.input.present, b.nullMode)
 }
 
 func (b int8Builder) Int2() pgtype.Int2 {
@@ -138,18 +179,25 @@ func (b int8Builder) Int8() pgtype.Int8 {
 }
 
 type int16Builder struct {
-	input      inputValue[int16]
-	zeroIsNull bool
+	input    inputValue[int16]
+	nullMode intNullMode
 }
 
 // ZeroIsNull makes the resulting pgtype value NULL when the input integer is 0.
 func (b int16Builder) ZeroIsNull() int16Builder {
-	b.zeroIsNull = true
+	b.nullMode = intNullZero
+	return b
+}
+
+// NonPositiveIsNull makes the resulting pgtype value NULL when the input integer
+// is <= 0 (zero or negative).
+func (b int16Builder) NonPositiveIsNull() int16Builder {
+	b.nullMode = intNullNonPositive
 	return b
 }
 
 func (b int16Builder) present() bool {
-	return intPresent(int64(b.input.value), b.input.present, b.zeroIsNull)
+	return intPresent(int64(b.input.value), b.input.present, b.nullMode)
 }
 
 func (b int16Builder) Int2() pgtype.Int2 {
@@ -165,18 +213,25 @@ func (b int16Builder) Int8() pgtype.Int8 {
 }
 
 type int32Builder struct {
-	input      inputValue[int32]
-	zeroIsNull bool
+	input    inputValue[int32]
+	nullMode intNullMode
 }
 
 // ZeroIsNull makes the resulting pgtype value NULL when the input integer is 0.
 func (b int32Builder) ZeroIsNull() int32Builder {
-	b.zeroIsNull = true
+	b.nullMode = intNullZero
+	return b
+}
+
+// NonPositiveIsNull makes the resulting pgtype value NULL when the input integer
+// is <= 0 (zero or negative).
+func (b int32Builder) NonPositiveIsNull() int32Builder {
+	b.nullMode = intNullNonPositive
 	return b
 }
 
 func (b int32Builder) present() bool {
-	return intPresent(int64(b.input.value), b.input.present, b.zeroIsNull)
+	return intPresent(int64(b.input.value), b.input.present, b.nullMode)
 }
 
 func (b int32Builder) Int2() pgtype.Int2 {
@@ -196,18 +251,25 @@ func (b int32Builder) Int8() pgtype.Int8 {
 }
 
 type int64Builder struct {
-	input      inputValue[int64]
-	zeroIsNull bool
+	input    inputValue[int64]
+	nullMode intNullMode
 }
 
 // ZeroIsNull makes the resulting pgtype value NULL when the input integer is 0.
 func (b int64Builder) ZeroIsNull() int64Builder {
-	b.zeroIsNull = true
+	b.nullMode = intNullZero
+	return b
+}
+
+// NonPositiveIsNull makes the resulting pgtype value NULL when the input integer
+// is <= 0 (zero or negative).
+func (b int64Builder) NonPositiveIsNull() int64Builder {
+	b.nullMode = intNullNonPositive
 	return b
 }
 
 func (b int64Builder) present() bool {
-	return intPresent(b.input.value, b.input.present, b.zeroIsNull)
+	return intPresent(b.input.value, b.input.present, b.nullMode)
 }
 
 func (b int64Builder) Int2() pgtype.Int2 {
@@ -231,18 +293,25 @@ func (b int64Builder) Int8() pgtype.Int8 {
 }
 
 type intBuilder struct {
-	input      inputValue[int]
-	zeroIsNull bool
+	input    inputValue[int]
+	nullMode intNullMode
 }
 
 // ZeroIsNull makes the resulting pgtype value NULL when the input integer is 0.
 func (b intBuilder) ZeroIsNull() intBuilder {
-	b.zeroIsNull = true
+	b.nullMode = intNullZero
+	return b
+}
+
+// NonPositiveIsNull makes the resulting pgtype value NULL when the input integer
+// is <= 0 (zero or negative).
+func (b intBuilder) NonPositiveIsNull() intBuilder {
+	b.nullMode = intNullNonPositive
 	return b
 }
 
 func (b intBuilder) present() bool {
-	return intPresent(int64(b.input.value), b.input.present, b.zeroIsNull)
+	return intPresent(int64(b.input.value), b.input.present, b.nullMode)
 }
 
 func (b intBuilder) Int2() pgtype.Int2 {
@@ -266,21 +335,39 @@ func (b intBuilder) Int8() pgtype.Int8 {
 }
 
 type float64Builder struct {
-	input      inputValue[float64]
-	zeroIsNull bool
+	input    inputValue[float64]
+	nullMode intNullMode
 }
 
 // ZeroIsNull makes the resulting pgtype value NULL when the input float is 0.
 func (b float64Builder) ZeroIsNull() float64Builder {
-	b.zeroIsNull = true
+	b.nullMode = intNullZero
 	return b
 }
 
-func (b float64Builder) Float8() pgtype.Float8 {
+// NonPositiveIsNull makes the resulting pgtype value NULL when the input float
+// is <= 0 (zero or negative).
+func (b float64Builder) NonPositiveIsNull() float64Builder {
+	b.nullMode = intNullNonPositive
+	return b
+}
+
+func (b float64Builder) valid() bool {
 	if !b.input.present {
-		return pgtype.Float8{}
+		return false
 	}
-	if b.zeroIsNull && b.input.value == 0 {
+	switch b.nullMode {
+	case intNullZero:
+		return b.input.value != 0
+	case intNullNonPositive:
+		return b.input.value > 0
+	default:
+		return true
+	}
+}
+
+func (b float64Builder) Float8() pgtype.Float8 {
+	if !b.valid() {
 		return pgtype.Float8{}
 	}
 	return pgtype.Float8{Float64: b.input.value, Valid: true}

--- a/pgconv/pgencode/pgencode_test.go
+++ b/pgconv/pgencode/pgencode_test.go
@@ -29,6 +29,99 @@ func TestString(t *testing.T) {
 	}
 }
 
+func TestStringTrimSpace(t *testing.T) {
+	if got := pgencode.String("  hi  ").TrimSpace().Text(); !got.Valid || got.String != "hi" {
+		t.Fatalf("String(pad).TrimSpace().Text() = %#v", got)
+	}
+	// Composes with EmptyIsNull in either order; all-whitespace -> NULL.
+	if got := pgencode.String("   ").TrimSpace().EmptyIsNull().Text(); got.Valid {
+		t.Fatalf("String(ws).TrimSpace().EmptyIsNull().Text() = %#v", got)
+	}
+	if got := pgencode.String("   ").EmptyIsNull().TrimSpace().Text(); got.Valid {
+		t.Fatalf("String(ws).EmptyIsNull().TrimSpace().Text() = %#v", got)
+	}
+	// Trimmed-but-non-empty stays valid and carries the trimmed value.
+	if got := pgencode.String("\t x \n").TrimSpace().EmptyIsNull().Text(); !got.Valid || got.String != "x" {
+		t.Fatalf("String(pad).TrimSpace().EmptyIsNull().Text() = %#v", got)
+	}
+	// Without EmptyIsNull, an all-whitespace input trims to a valid empty string.
+	if got := pgencode.String("   ").TrimSpace().Text(); !got.Valid || got.String != "" {
+		t.Fatalf("String(ws).TrimSpace().Text() = %#v", got)
+	}
+	// StringPtr(nil) stays NULL regardless of TrimSpace.
+	if got := pgencode.StringPtr((*string)(nil)).TrimSpace().EmptyIsNull().Text(); got.Valid {
+		t.Fatalf("StringPtr(nil).TrimSpace().EmptyIsNull().Text() = %#v", got)
+	}
+}
+
+func TestIntegersNonPositiveIsNull(t *testing.T) {
+	// Positive values stay valid at every output width.
+	if got := pgencode.Int64(5).NonPositiveIsNull().Int8(); !got.Valid || got.Int64 != 5 {
+		t.Fatalf("Int64(5).NonPositiveIsNull().Int8() = %#v", got)
+	}
+	if got := pgencode.Int64(5).NonPositiveIsNull().Int4(); !got.Valid || got.Int32 != 5 {
+		t.Fatalf("Int64(5).NonPositiveIsNull().Int4() = %#v", got)
+	}
+	if got := pgencode.Int64(5).NonPositiveIsNull().Int2(); !got.Valid || got.Int16 != 5 {
+		t.Fatalf("Int64(5).NonPositiveIsNull().Int2() = %#v", got)
+	}
+
+	// Zero is NULL at every output width.
+	if got := pgencode.Int64(0).NonPositiveIsNull().Int8(); got.Valid {
+		t.Fatalf("Int64(0).NonPositiveIsNull().Int8() = %#v", got)
+	}
+	if got := pgencode.Int64(0).NonPositiveIsNull().Int4(); got.Valid {
+		t.Fatalf("Int64(0).NonPositiveIsNull().Int4() = %#v", got)
+	}
+	if got := pgencode.Int64(0).NonPositiveIsNull().Int2(); got.Valid {
+		t.Fatalf("Int64(0).NonPositiveIsNull().Int2() = %#v", got)
+	}
+
+	// Negative values are NULL too (this is the difference from ZeroIsNull).
+	if got := pgencode.Int64(-3).NonPositiveIsNull().Int8(); got.Valid {
+		t.Fatalf("Int64(-3).NonPositiveIsNull().Int8() = %#v", got)
+	}
+	if got := pgencode.Int64(-3).ZeroIsNull().Int8(); !got.Valid || got.Int64 != -3 {
+		t.Fatalf("Int64(-3).ZeroIsNull().Int8() = %#v (negatives stay valid under ZeroIsNull)", got)
+	}
+
+	// Every integer constructor exposes NonPositiveIsNull with the same semantics.
+	if got := pgencode.Int8(-1).NonPositiveIsNull().Int8(); got.Valid {
+		t.Fatalf("Int8(-1).NonPositiveIsNull().Int8() = %#v", got)
+	}
+	if got := pgencode.Int8(2).NonPositiveIsNull().Int8(); !got.Valid || got.Int64 != 2 {
+		t.Fatalf("Int8(2).NonPositiveIsNull().Int8() = %#v", got)
+	}
+	if got := pgencode.Int16(0).NonPositiveIsNull().Int4(); got.Valid {
+		t.Fatalf("Int16(0).NonPositiveIsNull().Int4() = %#v", got)
+	}
+	if got := pgencode.Int32(-5).NonPositiveIsNull().Int4(); got.Valid {
+		t.Fatalf("Int32(-5).NonPositiveIsNull().Int4() = %#v", got)
+	}
+	if got := pgencode.Int(4).NonPositiveIsNull().Int8(); !got.Valid || got.Int64 != 4 {
+		t.Fatalf("Int(4).NonPositiveIsNull().Int8() = %#v", got)
+	}
+
+	// Composes with the checked (Try*) outputs.
+	if got, err := pgencode.Int64(-2).NonPositiveIsNull().TryInt4(); err != nil || got.Valid {
+		t.Fatalf("Int64(-2).NonPositiveIsNull().TryInt4() = %#v, err=%v", got, err)
+	}
+	if got, err := pgencode.Int64(7).NonPositiveIsNull().TryInt2(); err != nil || !got.Valid || got.Int16 != 7 {
+		t.Fatalf("Int64(7).NonPositiveIsNull().TryInt2() = %#v, err=%v", got, err)
+	}
+
+	// Float variant mirrors the integer semantics.
+	if got := pgencode.Float64(-1.5).NonPositiveIsNull().Float8(); got.Valid {
+		t.Fatalf("Float64(-1.5).NonPositiveIsNull().Float8() = %#v", got)
+	}
+	if got := pgencode.Float64(0).NonPositiveIsNull().Float8(); got.Valid {
+		t.Fatalf("Float64(0).NonPositiveIsNull().Float8() = %#v", got)
+	}
+	if got := pgencode.Float64(2.5).NonPositiveIsNull().Float8(); !got.Valid || got.Float64 != 2.5 {
+		t.Fatalf("Float64(2.5).NonPositiveIsNull().Float8() = %#v", got)
+	}
+}
+
 func TestBool(t *testing.T) {
 	if got := pgencode.Bool(true).Bool(); !got.Valid || !got.Bool {
 		t.Fatalf("Bool().Bool() = %#v", got)


### PR DESCRIPTION
## Summary

Adds three `pgconv` helpers so a few remaining backend "optional value" wrapper patterns become expressible as builder chains, and teaches `pgconvlint` to suggest the new chains where statically detectable. Mirrors the style of #15 (value-receiver builder methods, flag on the builder struct, golden testdata).

## New helpers

### pgencode

- **`func (stringBuilder) TrimSpace() stringBuilder`** — trims leading/trailing whitespace (`strings.TrimSpace`) from the input before value/validity are computed. Composes with `EmptyIsNull()` in either order.
  - `pgencode.String(v).TrimSpace().EmptyIsNull().Text()` reproduces the backend `optText` (trim, then empty→NULL; all-whitespace → NULL).
- **`func (int8Builder) NonPositiveIsNull() int8Builder`** (and `int16Builder`, `int32Builder`, `int64Builder`, `intBuilder`, `float64Builder`) — resulting pgtype is NULL when the input is `<= 0` (zero **or negative**), else valid. Distinct from `ZeroIsNull()`, which is NULL only when `== 0`.
  - `pgencode.Int64(v).NonPositiveIsNull().Int8()` reproduces the backend `optInt8` (`if value <= 0 { return pgtype.Int8{} }`).
  - The float variant is included for symmetry — it was low-cost and consistent with the existing `ZeroIsNull()` set.

Implementation note: the integer builders' shared `intPresent` gained an `intNullMode` enum (`none`/`zero`/`nonPositive`) in place of the old `zeroIsNull bool`, so both modifiers thread through one predicate. `float64Builder` gained a matching `valid()` helper.

### pgdecode

- **`func CoalesceText(values ...pgtype.Text) textBuilder`** — returns a `textBuilder` over the first argument that decodes to a **non-empty** string (stronger than `Valid`: a `Valid` value whose `String` is `""` is skipped). If every argument decodes to `""`, the builder resolves as a valid empty string, so `.Value()` returns `""` and `.Ptr()/.Fill()` still yield the empty value. Semantics are documented on the function.
  - `pgdecode.CoalesceText(description, title).Value()` reproduces the backend `subjectMemorySummary` (prefer non-empty description, else title). I chose the variadic constructor over a chaining `.Or(next)` because it reads as an n-way "first non-empty" and mirrors the wrapper, which takes both values up front.

## pgconvlint suggestion additions

- Encode composite literal whose value is `strings.TrimSpace(x)` and whose `Valid` is empty-based (`strings.TrimSpace(x) != ""`) → suggests + auto-fixes to `pgencode.String(x).TrimSpace().EmptyIsNull().Text()` (the `strings.TrimSpace` call is unwrapped for the constructor arg).
- Integer/float encode literal with `Valid: v > 0` or `Valid: 0 < v` (NULL when `v <= 0`) → suggests `.NonPositiveIsNull()`. This is kept distinct from `Valid: v != 0`, which continues to map to `.ZeroIsNull()`.
- All existing suggestions (`EmptyIsNull`, `ZeroIsNull`, `StringPtr`, decode `Fill`/`Value`, tiny-wrapper inlining, …) are preserved. Golden testdata (`testdata/src/a/a.go` + `.golden`) and the testdata `pgencode` stub are extended for the new methods.
- The decode coalesce pattern is control-flow (if/else) and is **not** statically matched by the composite-literal/selector rules; I intentionally did not add analyzer detection for `CoalesceText` — only the runtime helper.

## `tsParam` needs no new helper

The backend `tsParam` (`if t.IsZero() { return pgtype.Timestamptz{} }`) is already expressible with the existing `pgencode.Time(t).ZeroIsNull().Timestamptz()` — `timeBuilder.ZeroIsNull().valid()` returns false when `input.value.IsZero()`. No go-kit change is needed; the backend can just inline it.

## Verification

- `go test ./...` and `go vet ./...` green in the `pgconv` module (pgencode, pgdecode, pgconvlint golden tests).
- `gofmt -l` clean on all touched files.
- New unit tests: `TestStringTrimSpace`, `TestIntegersNonPositiveIsNull` (0/negative → NULL, positive → valid across Int2/Int4/Int8 + Try* + float), `TestCoalesceText` (first non-empty wins; empty-but-Valid and NULL skipped; all-empty → `""`; `.Value()/.Ptr()/.Fill()`).

## Backend follow-up (separate PR)

After a new `pgconv` release, the backend can inline and delete these wrappers and remove their `//lint:ignore pgconvlint` suppressions and dedicated helper tests:

- `optText(v)` → `pgencode.String(v).TrimSpace().EmptyIsNull().Text()`
- `optInt8(v)` → `pgencode.Int64(v).NonPositiveIsNull().Int8()`
- `subjectMemorySummary(title, description)` → `pgdecode.CoalesceText(description, title).Value()`
- `tsParam(t)` → `pgencode.Time(t).ZeroIsNull().Timestamptz()` (no new helper needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added string trimming support when converting values, including better handling of whitespace-only input.
  * Added a new option for numeric values where zero and negative values can be treated as null.
  * Added text coalescing support to choose the first non-empty value from multiple inputs.

* **Bug Fixes**
  * Improved conversion suggestions so they more accurately match trimmed strings and positive-value checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->