### PR TITLE
feat(pgconv): add pgdecode AppendValid to fold Valid-guarded slice appends

### DIFF
--- a/pgconv/pgdecode/pgdecode.go
+++ b/pgconv/pgdecode/pgdecode.go
@@ -654,6 +654,98 @@ func (b numericInt64Builder) Fill(ptr *int64) error {
 	return nil
 }
 
+// AppendValid appends the decoded value to dst and returns the result when the
+// source is non-NULL (or a Fallback was set); otherwise dst is returned
+// unchanged. It collapses the common `if v.Valid { s = append(s, v.T) }` guard
+// into a single expression, mirroring Fill's write-only-when-valid semantics.
+func (b textBuilder) AppendValid(dst []string) []string {
+	if value, ok := b.value.resolve(""); ok {
+		return append(dst, value)
+	}
+	return dst
+}
+
+// AppendValid appends the decoded value to dst when the source is non-NULL.
+func (b boolBuilder) AppendValid(dst []bool) []bool {
+	if value, ok := b.value.resolve(false); ok {
+		return append(dst, value)
+	}
+	return dst
+}
+
+// AppendValid appends the decoded value to dst when the source is non-NULL.
+func (b int2Builder) AppendValid(dst []int16) []int16 {
+	if value, ok := b.value.resolve(0); ok {
+		return append(dst, value)
+	}
+	return dst
+}
+
+// AppendValid appends the decoded value to dst when the source is non-NULL.
+func (b int4Builder) AppendValid(dst []int32) []int32 {
+	if value, ok := b.value.resolve(0); ok {
+		return append(dst, value)
+	}
+	return dst
+}
+
+// AppendValid appends the decoded value to dst when the source is non-NULL.
+func (b int8Builder) AppendValid(dst []int64) []int64 {
+	if value, ok := b.value.resolve(0); ok {
+		return append(dst, value)
+	}
+	return dst
+}
+
+// AppendValid appends the decoded value to dst when the source is non-NULL and
+// fits in an int.
+func (b safeIntBuilder) AppendValid(dst []int) []int {
+	if value, ok := b.resolved(); ok {
+		return append(dst, value)
+	}
+	return dst
+}
+
+// AppendValid appends the decoded value to dst when the source is non-NULL.
+func (b float8Builder) AppendValid(dst []float64) []float64 {
+	if value, ok := b.value.resolve(0); ok {
+		return append(dst, value)
+	}
+	return dst
+}
+
+// AppendValid appends the decoded value to dst when the source is a finite date.
+func (b dateBuilder) AppendValid(dst []time.Time) []time.Time {
+	if value, ok := b.value.resolve(time.Time{}); ok {
+		return append(dst, value)
+	}
+	return dst
+}
+
+// AppendValid appends the decoded value to dst when the source is a finite timestamp.
+func (b timestampBuilder) AppendValid(dst []time.Time) []time.Time {
+	if value, ok := b.value.resolve(time.Time{}); ok {
+		return append(dst, value)
+	}
+	return dst
+}
+
+// AppendValid appends the decoded value to dst when the source is a finite timestamptz.
+func (b timestamptzBuilder) AppendValid(dst []time.Time) []time.Time {
+	if value, ok := b.value.resolve(time.Time{}); ok {
+		return append(dst, value)
+	}
+	return dst
+}
+
+// AppendValid appends the decoded value to dst when the source is non-NULL.
+func (b uuidBuilder) AppendValid(dst []uuid.UUID) []uuid.UUID {
+	if value, ok := b.value.resolve(uuid.Nil); ok {
+		return append(dst, value)
+	}
+	return dst
+}
+
 func Text(value pgtype.Text) textBuilder {
 	return textBuilder{value: newNullableValue(value.Valid, value.String)}
 }

--- a/pgconv/pgdecode/pgdecode_test.go
+++ b/pgconv/pgdecode/pgdecode_test.go
@@ -307,3 +307,50 @@ func TestNumeric(t *testing.T) {
 		t.Fatalf("Numeric.Int64().Fallback().Fill() changed value to %d", intSeed)
 	}
 }
+
+func TestAppendValid(t *testing.T) {
+	// Text: valid appends, NULL skips, Fallback counts as present.
+	var ids []string
+	ids = pgdecode.Text(pgtype.Text{String: "a", Valid: true}).AppendValid(ids)
+	ids = pgdecode.Text(pgtype.Text{}).AppendValid(ids) // NULL -> skipped
+	ids = pgdecode.Text(pgtype.Text{String: "", Valid: true}).AppendValid(ids)
+	ids = pgdecode.Text(pgtype.Text{}).Fallback("fb").AppendValid(ids)
+	if want := []string{"a", "", "fb"}; !equalStrings(ids, want) {
+		t.Fatalf("Text.AppendValid() = %#v, want %#v", ids, want)
+	}
+
+	// Int8: valid appends, NULL skips.
+	var nums []int64
+	nums = pgdecode.Int8(pgtype.Int8{Int64: 7, Valid: true}).AppendValid(nums)
+	nums = pgdecode.Int8(pgtype.Int8{}).AppendValid(nums)
+	nums = pgdecode.Int8(pgtype.Int8{Int64: 9, Valid: true}).AppendValid(nums)
+	if want := []int64{7, 9}; len(nums) != len(want) || nums[0] != 7 || nums[1] != 9 {
+		t.Fatalf("Int8.AppendValid() = %#v, want %#v", nums, want)
+	}
+
+	// UUID: valid appends, NULL skips.
+	u := uuid.New()
+	var uuids []uuid.UUID
+	uuids = pgdecode.UUID(pgtype.UUID{Bytes: u, Valid: true}).AppendValid(uuids)
+	uuids = pgdecode.UUID(pgtype.UUID{}).AppendValid(uuids)
+	if len(uuids) != 1 || uuids[0] != u {
+		t.Fatalf("UUID.AppendValid() = %#v, want [%v]", uuids, u)
+	}
+
+	// nil destination stays nil when nothing is valid.
+	if got := pgdecode.Text(pgtype.Text{}).AppendValid(nil); got != nil {
+		t.Fatalf("Text(NULL).AppendValid(nil) = %#v, want nil", got)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## What

Adds `AppendValid(dst []T) []T` to the `pgdecode` value builders so a `Valid`-guarded slice append becomes a single expression.

**Before**
```go
for _, row := range rows {
    if row.FirestorePairID.Valid {
        ids = append(ids, row.FirestorePairID.String)
    }
}
```

**After**
```go
for _, row := range rows {
    ids = pgdecode.Text(row.FirestorePairID).AppendValid(ids)
}
```

## Semantics

Appends the decoded value and returns the slice when the source is non-NULL (or a `Fallback` was set); otherwise returns `dst` unchanged — the slice analogue of `Fill(&dst)` (write only when valid). Same finite-time handling as `Value()` for Date/Timestamp/Timestamptz.

Added on: `textBuilder`, `boolBuilder`, `int2Builder`, `int4Builder`, `int8Builder`, `safeIntBuilder`, `float8Builder`, `dateBuilder`, `timestampBuilder`, `timestamptzBuilder`, `uuidBuilder`. Error-returning builders (`intBuilder`, `numeric*`) are intentionally omitted — an append that can fail doesn't compose cleanly.

## Tests

`TestAppendValid` covers valid-appends / NULL-skips / `Fallback`-counts-as-present across Text, Int8, UUID, plus the nil-destination case. `go test ./...`, `go vet ./...`, `gofmt -l` all clean in the `pgconv` module.

## Backend follow-up

ditto-assistant/backend PR #1734 will bump the `pgconv` dep and use `AppendValid` at the `GetPairsBySubjectIDs` site flagged in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
