### PR TITLE
feat(pgconv): add pgencode String Fallback(pgtype.Text)

### DIFF
--- a/pgconv/pgencode/pgencode.go
+++ b/pgconv/pgencode/pgencode.go
@@ -71,10 +71,26 @@ type stringBuilder struct {
 	input       inputValue[string]
 	emptyIsNull bool
 	trimSpace   bool
+	fallback    *pgtype.Text
 }
 
 func (b stringBuilder) EmptyIsNull() stringBuilder {
 	b.emptyIsNull = true
+	return b
+}
+
+// Fallback substitutes the given pgtype.Text whenever Text() would otherwise
+// produce NULL (the input is absent, or it is empty and EmptyIsNull() was set).
+// It expresses "prefer this string, otherwise keep an existing column value"
+// in a single expression, e.g.
+//
+//	params.CancellationFeedback = pgencode.String(stripeVal).EmptyIsNull().Fallback(row.CancellationFeedback).Text()
+//
+// preserves row.CancellationFeedback exactly (its Valid flag and String)
+// when stripeVal is empty, and overwrites it otherwise. The fallback is
+// returned verbatim, so a NULL fallback stays NULL.
+func (b stringBuilder) Fallback(value pgtype.Text) stringBuilder {
+	b.fallback = &value
 	return b
 }
 
@@ -95,14 +111,14 @@ func (b stringBuilder) resolved() string {
 }
 
 func (b stringBuilder) Text() pgtype.Text {
-	if !b.input.present {
-		return pgtype.Text{}
-	}
 	value := b.resolved()
-	if b.emptyIsNull && value == "" {
-		return pgtype.Text{}
+	if b.input.present && !(b.emptyIsNull && value == "") {
+		return pgtype.Text{String: value, Valid: true}
 	}
-	return pgtype.Text{String: value, Valid: true}
+	if b.fallback != nil {
+		return *b.fallback
+	}
+	return pgtype.Text{}
 }
 
 type boolBuilder struct {

--- a/pgconv/pgencode/pgencode_test.go
+++ b/pgconv/pgencode/pgencode_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/omniaura/go-kit/pgconv/pgencode"
 )
 
@@ -282,5 +283,40 @@ func TestUUID(t *testing.T) {
 	}
 	if got := pgencode.UUIDPtr((*uuid.UUID)(nil)).UUID(); got.Valid {
 		t.Fatalf("UUIDPtr(nil).UUID() = %#v", got)
+	}
+}
+
+func TestStringFallback(t *testing.T) {
+	existing := pgtype.Text{String: "kept", Valid: true}
+
+	// Non-empty input wins; the fallback is ignored.
+	if got := pgencode.String("new").EmptyIsNull().Fallback(existing).Text(); !got.Valid || got.String != "new" {
+		t.Fatalf("String(new).Fallback().Text() = %#v, want valid \"new\"", got)
+	}
+
+	// Empty input with EmptyIsNull returns the fallback verbatim (Valid + String).
+	if got := pgencode.String("").EmptyIsNull().Fallback(existing).Text(); got != existing {
+		t.Fatalf("String(empty).EmptyIsNull().Fallback(existing).Text() = %#v, want %#v", got, existing)
+	}
+
+	// A NULL fallback stays NULL.
+	if got := pgencode.String("").EmptyIsNull().Fallback(pgtype.Text{}).Text(); got.Valid {
+		t.Fatalf("String(empty).Fallback(NULL).Text() = %#v, want NULL", got)
+	}
+
+	// A valid-but-empty fallback is preserved exactly (not collapsed to NULL).
+	emptyValid := pgtype.Text{String: "", Valid: true}
+	if got := pgencode.String("").EmptyIsNull().Fallback(emptyValid).Text(); got != emptyValid {
+		t.Fatalf("Fallback(validEmpty).Text() = %#v, want %#v", got, emptyValid)
+	}
+
+	// Without EmptyIsNull an empty input is itself valid, so the fallback is unused.
+	if got := pgencode.String("").Fallback(existing).Text(); !got.Valid || got.String != "" {
+		t.Fatalf("String(empty).Fallback().Text() = %#v, want valid \"\"", got)
+	}
+
+	// A nil-pointer input (absent) also falls back.
+	if got := pgencode.StringPtr(nil).Fallback(existing).Text(); got != existing {
+		t.Fatalf("StringPtr(nil).Fallback(existing).Text() = %#v, want %#v", got, existing)
 	}
 }


### PR DESCRIPTION
## What

Adds `stringBuilder.Fallback(pgtype.Text)` to `pgencode`. When `Text()` would produce NULL (input absent, or empty with `EmptyIsNull()`), it returns the given `pgtype.Text` instead — verbatim, so a valid-but-empty or NULL fallback is preserved exactly.

## Why

Expresses "prefer this string, otherwise keep an existing column value" in a single expression. Motivating case (ditto-assistant/backend `applyReconcile`, where params are seeded with the DB row and only overwritten when Stripe reports a value):

```go
// before
params.CancellationFeedback = row.CancellationFeedback
if s := string(sub.CancellationDetails.Feedback); s != "" {
    params.CancellationFeedback = pgencode.String(s).EmptyIsNull().Text()
}

// after
params.CancellationFeedback = pgencode.String(string(sub.CancellationDetails.Feedback)).
    EmptyIsNull().Fallback(row.CancellationFeedback).Text()
```

## Semantics

- Non-empty input → fresh valid `Text` (fallback ignored).
- Empty input + `EmptyIsNull()` → fallback returned verbatim (Valid+String preserved; NULL stays NULL; valid-empty stays valid-empty).
- Without `EmptyIsNull()`, an empty input is itself valid, so the fallback is unused.
- Absent input (`StringPtr(nil)`) also falls back.

`TestStringFallback` covers all of the above. `go test ./...`, `go vet ./...`, `gofmt -l` clean in the `pgconv` module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional fallback support for text encoding, allowing empty or null-like string values to resolve to a configured default.
  * Improved string handling so provided values still take precedence over any fallback.

* **Bug Fixes**
  * Preserved empty versus null text values more consistently when encoding strings and string pointers.
  * Kept fallback values unchanged, including empty or null states, for more predictable output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->