### PR TITLE
feat: add shared string helpers

### DIFF
--- a/go.work
+++ b/go.work
@@ -15,5 +15,6 @@ use (
 	./shutdown
 	./slicer
 	./sqlconv
+	./strutils
 	./tasker
 )

--- a/pgconv/pgerr/pgerr.go
+++ b/pgconv/pgerr/pgerr.go
@@ -1,0 +1,15 @@
+// Package pgerr contains small helpers for classifying PostgreSQL errors.
+package pgerr
+
+import (
+	"errors"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// IsUniqueViolation reports whether err wraps a PostgreSQL unique_violation
+// error (SQLSTATE 23505).
+func IsUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
+}

--- a/pgconv/pgerr/pgerr_test.go
+++ b/pgconv/pgerr/pgerr_test.go
@@ -1,0 +1,36 @@
+package pgerr_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/omniaura/go-kit/pgconv/pgerr"
+)
+
+func TestIsUniqueViolation(t *testing.T) {
+	uniqueErr := &pgconn.PgError{Code: "23505"}
+	if !pgerr.IsUniqueViolation(uniqueErr) {
+		t.Fatal("IsUniqueViolation() = false for unique violation")
+	}
+
+	wrapped := fmt.Errorf("insert user: %w", uniqueErr)
+	if !pgerr.IsUniqueViolation(wrapped) {
+		t.Fatal("IsUniqueViolation() = false for wrapped unique violation")
+	}
+}
+
+func TestIsUniqueViolationFalse(t *testing.T) {
+	tests := []error{
+		nil,
+		errors.New("plain error"),
+		&pgconn.PgError{Code: "23503"},
+	}
+
+	for _, err := range tests {
+		if pgerr.IsUniqueViolation(err) {
+			t.Fatalf("IsUniqueViolation(%v) = true", err)
+		}
+	}
+}

--- a/strutils/go.mod
+++ b/strutils/go.mod
@@ -1,0 +1,5 @@
+module github.com/omniaura/go-kit/strutils
+
+go 1.25.5
+
+toolchain go1.26.1

--- a/strutils/slugify.go
+++ b/strutils/slugify.go
@@ -1,0 +1,35 @@
+package strutils
+
+import "strings"
+
+// Slugify lowercases s and reduces it to the [a-z0-9-] character set,
+// collapsing spaces, dashes, underscores, and dots into single dashes.
+func Slugify(s string) string {
+	var b strings.Builder
+	lastHyphen := false
+
+	for _, r := range strings.ToLower(strings.TrimSpace(s)) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			lastHyphen = false
+		case r == ' ' || r == '-' || r == '_' || r == '.':
+			if !lastHyphen && b.Len() > 0 {
+				b.WriteRune('-')
+				lastHyphen = true
+			}
+		}
+	}
+
+	return strings.TrimRight(b.String(), "-")
+}
+
+// SlugifyMax is Slugify followed by a byte-length cap. A non-positive max
+// disables the cap.
+func SlugifyMax(s string, maxBytes int) string {
+	out := Slugify(s)
+	if maxBytes > 0 && len(out) > maxBytes {
+		out = strings.Trim(out[:maxBytes], "-")
+	}
+	return out
+}

--- a/strutils/slugify_test.go
+++ b/strutils/slugify_test.go
@@ -1,0 +1,41 @@
+package strutils_test
+
+import (
+	"testing"
+
+	"github.com/omniaura/go-kit/strutils"
+)
+
+func TestSlugify(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "simple", input: "Hello World", want: "hello-world"},
+		{name: "collapses separators", input: " hello---world__again.now ", want: "hello-world-again-now"},
+		{name: "drops unsupported runes", input: "Caf\u00e9 \u2603", want: "caf"},
+		{name: "trims dashes", input: "---hello---", want: "hello"},
+		{name: "empty", input: " \u2603 ", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := strutils.Slugify(tt.input); got != tt.want {
+				t.Fatalf("Slugify(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSlugifyMax(t *testing.T) {
+	if got := strutils.SlugifyMax("Hello Big World", 9); got != "hello-big" {
+		t.Fatalf("SlugifyMax() = %q", got)
+	}
+	if got := strutils.SlugifyMax("Hello Big World", 0); got != "hello-big-world" {
+		t.Fatalf("SlugifyMax(no cap) = %q", got)
+	}
+	if got := strutils.SlugifyMax("Hello Big World", 6); got != "hello" {
+		t.Fatalf("SlugifyMax(trim dash) = %q", got)
+	}
+}

--- a/strutils/text.go
+++ b/strutils/text.go
@@ -1,0 +1,179 @@
+package strutils
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+const previewMaxBytes = 240
+
+// FirstNonBlank returns the first value whose trimmed form is not empty.
+// The original, untrimmed value is returned.
+func FirstNonBlank(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+// FirstTrimmedNonBlank returns the first non-blank value after trimming space.
+func FirstTrimmedNonBlank(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+// ContainsFold reports whether items contains needle under Unicode case folding.
+func ContainsFold[S ~string](items []S, needle string) bool {
+	for _, item := range items {
+		if strings.EqualFold(string(item), needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// QuotedPreview returns a JSON-quoted preview of raw, truncated to a bounded
+// byte prefix before quoting.
+func QuotedPreview(raw string) string {
+	preview := TruncateUTF8(raw, previewMaxBytes, "...")
+	data, err := json.Marshal(preview)
+	if err != nil {
+		return preview
+	}
+	return string(data)
+}
+
+// TypedPreview returns the Go type of v followed by a compact JSON preview.
+// If v cannot be marshaled as JSON, only the Go type is returned.
+func TypedPreview(v any) string {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%T", v)
+	}
+
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, data); err != nil {
+		return fmt.Sprintf("%T", v)
+	}
+
+	return fmt.Sprintf("%T %s", v, TruncateUTF8(compact.String(), previewMaxBytes, "..."))
+}
+
+// TruncateEllipsis truncates text to at most maxBytes bytes, using "..." when
+// there is room for the full marker.
+func TruncateEllipsis(text string, maxBytes int) string {
+	if len(text) <= maxBytes {
+		return text
+	}
+	if maxBytes <= 0 {
+		return ""
+	}
+	if maxBytes <= 3 {
+		return strings.Repeat(".", maxBytes)
+	}
+	return TruncateUTF8(text, maxBytes-3, "...")
+}
+
+// TrimMax trims surrounding whitespace, then truncates the result to at most
+// maxBytes bytes while preserving UTF-8 validity.
+func TrimMax(value string, maxBytes int) string {
+	value = strings.TrimSpace(value)
+	return TruncateUTF8(value, maxBytes, "")
+}
+
+// MiddleTruncateUTF8 truncates s to fit within maxBytes by preserving the
+// beginning and end of the string and replacing the middle with a marker.
+func MiddleTruncateUTF8(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	if maxBytes <= 0 {
+		return ""
+	}
+
+	approxTruncatedBytes := max(len(s)-maxBytes, 1)
+	marker := "[cut]"
+	if maxBytes >= len(cutTruncationMarker(approxTruncatedBytes))+4 {
+		estimatedCutBytes := len(s) - maxBytes + len(cutTruncationMarker(approxTruncatedBytes))
+		marker = cutTruncationMarker(estimatedCutBytes)
+	}
+
+	contextBudget := maxBytes - len(marker)
+	if contextBudget < 0 {
+		if maxBytes >= 3 {
+			return "..."
+		}
+		return strings.Repeat(".", maxBytes)
+	}
+
+	prefix, suffix := middleTruncateSegments(s, contextBudget)
+	return prefix + marker + suffix
+}
+
+func middleTruncateSegments(s string, totalBudget int) (string, string) {
+	if totalBudget <= 0 {
+		return "", ""
+	}
+
+	prefixBudget := totalBudget / 2
+	suffixBudget := totalBudget - prefixBudget
+
+	prefix := s[:prefixBudget]
+	for len(prefix) > 0 && !utf8.ValidString(prefix) {
+		prefix = prefix[:len(prefix)-1]
+	}
+
+	suffixStart := max(len(s)-suffixBudget, len(prefix))
+	for suffixStart < len(s) && !utf8.RuneStart(s[suffixStart]) {
+		suffixStart++
+	}
+
+	return prefix, s[suffixStart:]
+}
+
+func formatTruncatedBytes(n int) string {
+	switch {
+	case n < 1000:
+		return fmt.Sprintf("%db", n)
+	case n < 1000000:
+		return formatTruncatedUnit(float64(n)/1000, "kb")
+	default:
+		return formatTruncatedUnit(float64(n)/1000000, "mb")
+	}
+}
+
+func formatTruncatedUnit(value float64, unit string) string {
+	formatted := fmt.Sprintf("%.1f", value)
+	formatted = strings.TrimSuffix(formatted, ".0")
+	return formatted + unit
+}
+
+func cutTruncationMarker(n int) string {
+	return fmt.Sprintf("[%s cut]", formatTruncatedBytes(n))
+}
+
+// TruncateUTF8 truncates s to a valid UTF-8 prefix of at most maxBytes bytes,
+// then appends suffix when truncation occurs.
+func TruncateUTF8(s string, maxBytes int, suffix string) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	if maxBytes <= 0 {
+		return suffix
+	}
+
+	truncated := s[:maxBytes]
+	for len(truncated) > 0 && !utf8.ValidString(truncated) {
+		truncated = truncated[:len(truncated)-1]
+	}
+	return truncated + suffix
+}

--- a/strutils/text_test.go
+++ b/strutils/text_test.go
@@ -1,0 +1,190 @@
+package strutils_test
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/omniaura/go-kit/strutils"
+)
+
+func TestFirstNonBlank(t *testing.T) {
+	if got := strutils.FirstNonBlank("", " \t", "  value  ", "fallback"); got != "  value  " {
+		t.Fatalf("FirstNonBlank() = %q", got)
+	}
+	if got := strutils.FirstNonBlank("", " "); got != "" {
+		t.Fatalf("FirstNonBlank(all blank) = %q", got)
+	}
+}
+
+func TestFirstTrimmedNonBlank(t *testing.T) {
+	if got := strutils.FirstTrimmedNonBlank("", " \t", "  value  ", "fallback"); got != "value" {
+		t.Fatalf("FirstTrimmedNonBlank() = %q", got)
+	}
+}
+
+func TestContainsFold(t *testing.T) {
+	type label string
+	items := []label{"Alpha", "beta"}
+	if !strutils.ContainsFold(items, "ALPHA") {
+		t.Fatal("ContainsFold() did not match case-insensitively")
+	}
+	if strutils.ContainsFold(items, "gamma") {
+		t.Fatal("ContainsFold() matched missing item")
+	}
+}
+
+func TestQuotedPreview(t *testing.T) {
+	got := strutils.QuotedPreview("hello\nworld")
+	want := `"hello\nworld"`
+	if got != want {
+		t.Fatalf("QuotedPreview() = %q, want %q", got, want)
+	}
+
+	long := strings.Repeat("a", 241)
+	got = strutils.QuotedPreview(long)
+	want = `"` + strings.Repeat("a", 240) + `..."`
+	if got != want {
+		t.Fatalf("QuotedPreview(long) = %q, want %q", got, want)
+	}
+}
+
+func TestTypedPreview(t *testing.T) {
+	got := strutils.TypedPreview(map[string]any{"name": "ditto", "ok": true})
+	if !strings.HasPrefix(got, "map[string]interface {} ") {
+		t.Fatalf("TypedPreview() type prefix = %q", got)
+	}
+	if !strings.Contains(got, `"name":"ditto"`) || !strings.Contains(got, `"ok":true`) {
+		t.Fatalf("TypedPreview() compact JSON = %q", got)
+	}
+
+	unmarshalable := func() {}
+	if got := strutils.TypedPreview(unmarshalable); got != "func()" {
+		t.Fatalf("TypedPreview(unmarshalable) = %q", got)
+	}
+}
+
+func TestTruncateEllipsis(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		maxBytes int
+		want     string
+	}{
+		{name: "no truncation", input: "hello", maxBytes: 10, want: "hello"},
+		{name: "ascii", input: "hello world", maxBytes: 8, want: "hello..."},
+		{name: "tiny", input: "hello", maxBytes: 2, want: ".."},
+		{name: "zero", input: "hello", maxBytes: 0, want: ""},
+		{name: "utf8", input: "a\u00e9bcd", maxBytes: 5, want: "a..."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := strutils.TruncateEllipsis(tt.input, tt.maxBytes)
+			if got != tt.want {
+				t.Fatalf("TruncateEllipsis(%q, %d) = %q, want %q", tt.input, tt.maxBytes, got, tt.want)
+			}
+			if len(got) > tt.maxBytes {
+				t.Fatalf("TruncateEllipsis() length = %d, max = %d", len(got), tt.maxBytes)
+			}
+			if !utf8.ValidString(got) {
+				t.Fatalf("TruncateEllipsis() returned invalid UTF-8: %q", got)
+			}
+		})
+	}
+}
+
+func TestTrimMax(t *testing.T) {
+	got := strutils.TrimMax("  a\u00e9b  ", 2)
+	if got != "a" {
+		t.Fatalf("TrimMax() = %q", got)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("TrimMax() returned invalid UTF-8: %q", got)
+	}
+}
+
+func TestTruncateUTF8(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		maxBytes int
+		suffix   string
+		want     string
+	}{
+		{name: "no truncation", input: "hello", maxBytes: 10, suffix: "...", want: "hello"},
+		{name: "exact size", input: "hello", maxBytes: 5, suffix: "...", want: "hello"},
+		{name: "ascii with suffix", input: "hello world", maxBytes: 5, suffix: "...", want: "hello..."},
+		{name: "utf8 boundary", input: "a\u00e9b", maxBytes: 2, suffix: "", want: "a"},
+		{name: "utf8 exact", input: "a\u00e9b", maxBytes: 3, suffix: "", want: "a\u00e9"},
+		{name: "zero returns suffix", input: "hello", maxBytes: 0, suffix: "...", want: "..."},
+		{name: "negative returns suffix", input: "hello", maxBytes: -1, suffix: "...", want: "..."},
+		{name: "cjk", input: "\u4e16\u754c", maxBytes: 3, suffix: "", want: "\u4e16"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := strutils.TruncateUTF8(tt.input, tt.maxBytes, tt.suffix)
+			if got != tt.want {
+				t.Fatalf("TruncateUTF8(%q, %d, %q) = %q, want %q", tt.input, tt.maxBytes, tt.suffix, got, tt.want)
+			}
+			if !utf8.ValidString(got) {
+				t.Fatalf("TruncateUTF8() returned invalid UTF-8: %q", got)
+			}
+		})
+	}
+}
+
+func TestMiddleTruncateUTF8(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		maxBytes int
+		want     string
+	}{
+		{name: "no truncation", input: "hello", maxBytes: 10, want: "hello"},
+		{name: "exact size", input: "hello", maxBytes: 5, want: "hello"},
+		{name: "uses byte marker", input: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", maxBytes: 32, want: "abcdefghijk[29b cut]OPQRSTUVWXYZ"},
+		{name: "middle marker", input: "abcdefghijklmnopqrstuvwxyz", maxBytes: 20, want: "abcde[14b cut]uvwxyz"},
+		{name: "small budget", input: "abcdefghij", maxBytes: 8, want: "a[cut]ij"},
+		{name: "zero", input: "abcdefghij", maxBytes: 0, want: ""},
+		{name: "two byte budget", input: "abcdefghij", maxBytes: 2, want: ".."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := strutils.MiddleTruncateUTF8(tt.input, tt.maxBytes)
+			if got != tt.want {
+				t.Fatalf("MiddleTruncateUTF8(%q, %d) = %q, want %q", tt.input, tt.maxBytes, got, tt.want)
+			}
+			if len(got) > tt.maxBytes {
+				t.Fatalf("MiddleTruncateUTF8() length = %d, max = %d", len(got), tt.maxBytes)
+			}
+			if !utf8.ValidString(got) {
+				t.Fatalf("MiddleTruncateUTF8() returned invalid UTF-8: %q", got)
+			}
+		})
+	}
+}
+
+func TestMiddleTruncateUTF8PreservesUTF8Boundaries(t *testing.T) {
+	input := "你好，this is a long UTF-8 string，再见"
+	got := strutils.MiddleTruncateUTF8(input, 24)
+
+	if !utf8.ValidString(got) {
+		t.Fatalf("expected valid UTF-8, got %q", got)
+	}
+	if len(got) > 24 {
+		t.Fatalf("MiddleTruncateUTF8() length = %d, max = 24", len(got))
+	}
+	if !strings.Contains(got, "[") || !strings.Contains(got, "cut") {
+		t.Fatalf("expected truncation marker, got %q", got)
+	}
+}
+
+func TestTypedPreviewTruncates(t *testing.T) {
+	got := strutils.TypedPreview([]string{strings.Repeat("x", 300)})
+	if !strings.Contains(got, "...") {
+		t.Fatalf("TypedPreview() did not truncate: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add a new `strutils` module with reusable string selection, preview, truncation, and slug helpers
- add `pgconv/pgerr.IsUniqueViolation` for shared pgx unique-violation checks
- include `strutils` in the workspace test set

## Notes
- intentionally left backend-local helpers out when they were policy-coupled or service-specific: `pgid.Optional`/`RawJSON`, `pgjson`, backend-shaped `hwrite.JSON`, `secretcrypto`, `toolargs`, `cliui`, and storage path/url helpers
- also left `TrimStuff` out because the existing pointer-mutating API needs a clearer generic contract before becoming public Go Kit API
- did not include HTML text escaping because callers can use the Go standard library (`html.EscapeString`)
- scanned the new helpers for string concatenation that should be `strings.Builder`; the remaining concatenations are fixed-size joins, while slug construction already uses `strings.Builder`

## Test plan
- `PATH=/opt/homebrew/bin:$PATH go test ./...` from `strutils`
- `PATH=/opt/homebrew/bin:$PATH go test ./pgerr` from `pgconv`
- `PATH=/opt/homebrew/bin:$PATH ./scripts/test-all.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added string utility helpers for picking the first non-blank value, case-insensitive matching, JSON-based preview formatting, and UTF-8-safe truncation utilities.
  * Added `Slugify` and `SlugifyMax` for generating length-limited, URL/file-friendly slugs.
  * Added a database error helper to detect PostgreSQL unique-violation errors.
* **Tests**
  * Added unit tests covering the new string helpers and unique-violation detection, including wrapping and UTF-8 edge cases.
* **Chores**
  * Updated module configuration for the string utilities package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->