### PR TITLE
feat: add structify — params-struct rewriter with whole-program caller updates

### DIFF
--- a/go.work
+++ b/go.work
@@ -16,6 +16,7 @@ use (
 	./shutdown
 	./slicer
 	./sqlconv
+	./structify
 	./strutils
 	./tasker
 )

--- a/structify/analyzer.go
+++ b/structify/analyzer.go
@@ -1,0 +1,60 @@
+package structify
+
+import (
+	"go/ast"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// Analyzer reports functions whose inputs should be grouped into a params
+// struct. Detection matches the classic funcparamlint rule: more than four
+// input parameters (including a leading context.Context).
+//
+// The analyzer only diagnoses; rewriting requires whole-program knowledge
+// of every caller, which is cmd/structify's job.
+var Analyzer = &analysis.Analyzer{
+	Name: analyzerName,
+	Doc: "check for functions whose inputs should be grouped into a struct; " +
+		"fix mechanically with the structify command; " +
+		"suppress with //lint:ignore structify <reason>",
+	URL: "https://pkg.go.dev/github.com/omniaura/go-kit/structify",
+	Run: runAnalyzer,
+}
+
+const analyzerMaxParams = 4
+
+func runAnalyzer(pass *analysis.Pass) (any, error) {
+	for _, file := range pass.Files {
+		tf := pass.Fset.File(file.FileStart)
+		if tf == nil || ast.IsGenerated(file) || strings.HasSuffix(tf.Name(), "_test.go") {
+			continue
+		}
+		sup := parseSuppressions(pass.Fset, file)
+		ast.Inspect(file, func(node ast.Node) bool {
+			switch n := node.(type) {
+			case *ast.FuncDecl:
+				if n.Body == nil {
+					return true
+				}
+				count := paramCount(n.Type.Params)
+				if count <= analyzerMaxParams || sup.ignored(pass.Fset, n.Name.Pos()) {
+					return true
+				}
+				kind, suggestion := "function", "move inputs into an input struct and make the behavior a method"
+				if n.Recv != nil {
+					kind, suggestion = "method", "move inputs into a request/options struct"
+				}
+				pass.Reportf(n.Name.Pos(), "%s %s has %d input parameters; %s", kind, n.Name.Name, count, suggestion)
+			case *ast.FuncLit:
+				count := paramCount(n.Type.Params)
+				if count <= analyzerMaxParams || sup.ignored(pass.Fset, n.Type.Func) {
+					return true
+				}
+				pass.Reportf(n.Type.Func, "function literal has %d input parameters; move inputs into an input struct before wiring this behavior", count)
+			}
+			return true
+		})
+	}
+	return nil, nil
+}

--- a/structify/cmd/structify/main.go
+++ b/structify/cmd/structify/main.go
@@ -1,0 +1,109 @@
+// Command structify rewrites functions with too many parameters to take a
+// generated params struct, updating every caller across the loaded
+// packages. See the package documentation for what is rewritten and what
+// is conservatively skipped.
+//
+// Usage:
+//
+//	structify [flags] [packages]
+//
+//	-fix            rewrite files in place (default: report only)
+//	-max-params N   flag functions with more than N inputs (default 4)
+//	-generated      also structify functions declared in generated files
+//	-tests          load test files so their call sites are rewritten (default true)
+//	-v              list skipped functions with reasons
+//
+// Exit status: report mode exits 1 when candidates exist; -fix exits 0
+// unless rewriting failed (skips are advisory, listed on stderr with -v).
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/format"
+	"os"
+
+	"github.com/omniaura/go-kit/structify"
+	"golang.org/x/tools/go/packages"
+)
+
+func main() {
+	var (
+		fix       = flag.Bool("fix", false, "rewrite files in place")
+		maxParams = flag.Int("max-params", 4, "flag functions with more than this many input parameters")
+		generated = flag.Bool("generated", false, "also structify functions declared in generated files")
+		tests     = flag.Bool("tests", true, "load test files so their call sites are rewritten")
+		verbose   = flag.Bool("v", false, "list skipped functions with reasons")
+	)
+	flag.Parse()
+	patterns := flag.Args()
+	if len(patterns) == 0 {
+		patterns = []string{"./..."}
+	}
+
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles |
+			packages.NeedImports | packages.NeedDeps | packages.NeedTypes |
+			packages.NeedSyntax | packages.NeedTypesInfo,
+		Tests: *tests,
+	}
+	pkgs, err := packages.Load(cfg, patterns...)
+	if err != nil {
+		fatal(err)
+	}
+	if packages.PrintErrors(pkgs) > 0 {
+		fatal(fmt.Errorf("packages contain errors"))
+	}
+
+	res, err := structify.Plan(pkgs, structify.Config{MaxParams: *maxParams, Generated: *generated})
+	if err != nil {
+		fatal(err)
+	}
+
+	if !*fix {
+		for _, t := range res.Rewritten {
+			fmt.Printf("%s: %s has %d input parameters; structify would generate %s and rewrite %d call sites\n",
+				t.Pos, t.Name, t.NumParams, t.StructName, t.NumCallers)
+		}
+		for _, t := range res.Skipped {
+			fmt.Printf("%s: %s has %d input parameters; cannot auto-fix: %s\n", t.Pos, t.Name, t.NumParams, t.SkipReason)
+		}
+		if len(res.Rewritten)+len(res.Skipped) > 0 {
+			os.Exit(1)
+		}
+		return
+	}
+
+	for filename, edits := range res.Edits {
+		src, err := os.ReadFile(filename)
+		if err != nil {
+			fatal(err)
+		}
+		out := structify.Apply(src, edits)
+		formatted, err := format.Source(out)
+		if err != nil {
+			fatal(fmt.Errorf("%s: formatting after rewrite: %w", filename, err))
+		}
+		if err := os.WriteFile(filename, formatted, 0o644); err != nil {
+			fatal(err)
+		}
+	}
+
+	fmt.Printf("structify: rewrote %d functions (%d files touched)\n", len(res.Rewritten), len(res.Edits))
+	for _, t := range res.Rewritten {
+		fmt.Printf("  %-50s -> %s (%d callers)\n", t.Name, t.StructName, t.NumCallers)
+	}
+	if len(res.Skipped) > 0 {
+		fmt.Printf("structify: %d functions skipped (run with -v for reasons)\n", len(res.Skipped))
+		if *verbose {
+			for _, t := range res.Skipped {
+				fmt.Fprintf(os.Stderr, "  skip %s: %s: %s\n", t.Pos, t.Name, t.SkipReason)
+			}
+		}
+	}
+}
+
+func fatal(err error) {
+	fmt.Fprintln(os.Stderr, "structify:", err)
+	os.Exit(2)
+}

--- a/structify/cmd/structify/main.go
+++ b/structify/cmd/structify/main.go
@@ -74,17 +74,27 @@ func main() {
 		return
 	}
 
+	// Rewrites are cross-file by design (a signature change plus all its
+	// callers), so validate and format EVERYTHING before writing anything:
+	// a mid-loop failure must not leave a half-applied, non-compiling tree.
+	type rewritten struct {
+		filename string
+		data     []byte
+	}
+	outputs := make([]rewritten, 0, len(res.Edits))
 	for filename, edits := range res.Edits {
 		src, err := os.ReadFile(filename)
 		if err != nil {
 			fatal(err)
 		}
-		out := structify.Apply(src, edits)
-		formatted, err := format.Source(out)
+		formatted, err := format.Source(structify.Apply(src, edits))
 		if err != nil {
 			fatal(fmt.Errorf("%s: formatting after rewrite: %w", filename, err))
 		}
-		if err := os.WriteFile(filename, formatted, 0o644); err != nil {
+		outputs = append(outputs, rewritten{filename, formatted})
+	}
+	for _, out := range outputs {
+		if err := os.WriteFile(out.filename, out.data, 0o644); err != nil {
 			fatal(err)
 		}
 	}

--- a/structify/go.mod
+++ b/structify/go.mod
@@ -1,0 +1,12 @@
+module github.com/omniaura/go-kit/structify
+
+go 1.25.5
+
+toolchain go1.26.1
+
+require golang.org/x/tools v0.44.0
+
+require (
+	golang.org/x/mod v0.35.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
+)

--- a/structify/go.sum
+++ b/structify/go.sum
@@ -1,0 +1,8 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
+golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
+golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=

--- a/structify/structify.go
+++ b/structify/structify.go
@@ -327,6 +327,12 @@ func (c *candidate) plan(fset *token.FileSet, ifaces []*types.Interface, refsByP
 		if p.name == nil || p.name.Name == "_" || p.name.Name == "" {
 			return "blank or unnamed parameter"
 		}
+		// A context belongs in the leading position, never in a struct
+		// field (per context package docs). Reorder the params by hand,
+		// then structify keeps it positional.
+		if isContextParam(c.pkg, p) {
+			return "context.Context parameter not in leading position"
+		}
 		fn := fieldName(p.name.Name)
 		if fieldNames[fn] {
 			return fmt.Sprintf("parameters %q collide as field %s", p.name.Name, fn)

--- a/structify/structify.go
+++ b/structify/structify.go
@@ -1,0 +1,746 @@
+// Package structify rewrites functions that take too many parameters into
+// functions that take a single generated params struct — and rewrites every
+// caller to match, across all loaded packages.
+//
+//	func CreateUser(ctx context.Context, name, email string, age int, admin bool) error
+//
+// becomes
+//
+//	// CreateUserParams bundles the parameters of CreateUser.
+//	type CreateUserParams struct {
+//		Name  string
+//		Email string
+//		Age   int
+//		Admin bool
+//	}
+//
+//	func CreateUser(ctx context.Context, arg CreateUserParams) error
+//
+// with every call site rewritten to CreateUser(ctx, CreateUserParams{Name: …}).
+// A leading context.Context parameter stays positional, per Go convention.
+//
+// Because a signature change is only safe when every reference is visible
+// and rewritable, a function is SKIPPED (diagnosed, not rewritten) when it:
+//
+//   - is variadic, generic, or has blank (_) parameters
+//   - is referenced as a function value (assigned, passed, stored)
+//   - is a method that satisfies an interface in the loaded packages
+//   - has callers in generated files (regeneration would break the build)
+//   - has a caller passing a multi-value call f(g()) or missing an import
+//     needed to name the params struct
+//   - carries a //go:* or //export directive
+//   - is suppressed with "//lint:ignore structify" (or the funcparamlint
+//     spelling) or "structify:ignore"
+//
+// The rewrite is text-based and formatting-preserving: caller edits are
+// zero-width insertions around the existing argument expressions, so they
+// compose with any other rewrites happening inside those arguments.
+package structify
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"sort"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// Config controls detection.
+type Config struct {
+	// MaxParams: functions with more input parameters than this are
+	// candidates. The count includes a leading context.Context, matching
+	// funcparamlint. Default 4.
+	MaxParams int
+	// Generated: also structify functions declared in generated files.
+	// Callers in generated files always block a rewrite regardless.
+	Generated bool
+}
+
+func (c Config) maxParams() int {
+	if c.MaxParams > 0 {
+		return c.MaxParams
+	}
+	return 4
+}
+
+// Edit is a text edit in a file: replace [Start, End) with Text.
+// Start == End is a pure insertion.
+type Edit struct {
+	Start, End int
+	Text       string
+}
+
+// Target is one candidate function.
+type Target struct {
+	// Name is the function or Recv.Method name for reporting.
+	Name string
+	// Pos is the position of the function name.
+	Pos token.Position
+	// StructName is the generated params struct name (empty when skipped).
+	StructName string
+	// NumParams is the input parameter count that triggered detection.
+	NumParams int
+	// NumCallers is the number of rewritten call sites.
+	NumCallers int
+	// SkipReason is non-empty when the function was diagnosed but not
+	// rewritten.
+	SkipReason string
+}
+
+// Result of planning over a package set.
+type Result struct {
+	Rewritten []*Target
+	Skipped   []*Target
+	// Edits maps filename to its edits, unsorted and deduplicated.
+	Edits map[string][]Edit
+}
+
+type field struct {
+	name     string // struct field name
+	typeText string // source text of the type
+	objs     []types.Object
+}
+
+type candidate struct {
+	pkg    *packages.Package
+	file   *ast.File
+	decl   *ast.FuncDecl
+	obj    *types.Func
+	target *Target
+
+	hasCtx     bool
+	fields     []field
+	argName    string
+	structName string
+	qualByFile map[string]string // filename -> qualifier ("", "pkg.")
+}
+
+// refInfo is one identifier reference to a function object.
+type refInfo struct {
+	pkg       *packages.Package
+	file      *ast.File
+	filename  string
+	ident     *ast.Ident
+	call      *ast.CallExpr // non-nil when the ref is the callee of this call
+	generated bool
+}
+
+// Plan computes the rewrite plan for all packages. pkgs should come from
+// packages.Load with syntax, types, deps and (ideally) Tests: true so
+// callers in test files are seen and rewritten.
+func Plan(pkgs []*packages.Package, cfg Config) (*Result, error) {
+	if len(pkgs) == 0 {
+		return &Result{Edits: map[string][]Edit{}}, nil
+	}
+	fset := pkgs[0].Fset
+
+	// ---- Pass 1: index every file once -------------------------------
+	type fileInfo struct {
+		pkg       *packages.Package
+		file      *ast.File
+		filename  string
+		src       []byte
+		generated bool
+		suppress  suppressions
+	}
+	var files []*fileInfo
+	seenFile := map[string]bool{}
+	// callee[ident] = enclosing call for idents in callee position
+	callee := map[*ast.Ident]*ast.CallExpr{}
+	// refs by target key (position of the object's declaration)
+	refsByPos := map[token.Pos][]refInfo{}
+	// interface method names -> interfaces (for the implements gate)
+	var ifaces []*types.Interface
+
+	var walkErr error
+	forEachPkg(pkgs, func(p *packages.Package) {
+		if p.TypesInfo == nil {
+			return
+		}
+		for i, f := range p.Syntax {
+			filename := p.CompiledGoFiles[i]
+			fi := &fileInfo{pkg: p, file: f, filename: filename, generated: ast.IsGenerated(f)}
+			if !seenFile[filename] {
+				seenFile[filename] = true
+				fi.suppress = parseSuppressions(fset, f)
+				files = append(files, fi)
+			}
+			ast.Inspect(f, func(n ast.Node) bool {
+				if call, ok := n.(*ast.CallExpr); ok {
+					switch fun := call.Fun.(type) {
+					case *ast.Ident:
+						callee[fun] = call
+					case *ast.SelectorExpr:
+						callee[fun.Sel] = call
+					}
+				}
+				return true
+			})
+			for ident, obj := range p.TypesInfo.Uses {
+				fn, ok := obj.(*types.Func)
+				if !ok || fn.Pos() == token.NoPos {
+					continue
+				}
+				if fset.File(ident.Pos()) == nil || fset.Position(ident.Pos()).Filename != filename {
+					continue
+				}
+				refsByPos[fn.Pos()] = append(refsByPos[fn.Pos()], refInfo{
+					pkg: p, file: f, filename: filename, ident: ident,
+					call: callee[ident], generated: fi.generated,
+				})
+			}
+		}
+		// Collect interfaces for the implements gate.
+		scope := p.Types.Scope()
+		for _, name := range scope.Names() {
+			tn, ok := scope.Lookup(name).(*types.TypeName)
+			if !ok {
+				continue
+			}
+			if intf, ok := tn.Type().Underlying().(*types.Interface); ok && intf.NumMethods() > 0 {
+				ifaces = append(ifaces, intf)
+			}
+		}
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+
+	// ---- Pass 2: find candidates in primary packages -----------------
+	res := &Result{Edits: map[string][]Edit{}}
+	reserved := map[*types.Package]map[string]bool{} // struct names claimed per package
+	seenDecl := map[token.Pos]bool{}
+
+	var cands []*candidate
+	forEachPkg(pkgs, func(p *packages.Package) {
+		if p.TypesInfo == nil {
+			return
+		}
+		for i, f := range p.Syntax {
+			filename := p.CompiledGoFiles[i]
+			for _, decl := range f.Decls {
+				fd, ok := decl.(*ast.FuncDecl)
+				if !ok || fd.Body == nil || seenDecl[fd.Name.Pos()] {
+					continue
+				}
+				seenDecl[fd.Name.Pos()] = true
+				n := paramCount(fd.Type.Params)
+				if n <= cfg.maxParams() {
+					continue
+				}
+				if strings.HasSuffix(filename, "_test.go") {
+					continue
+				}
+				if ast.IsGenerated(f) && !cfg.Generated {
+					continue
+				}
+				obj, ok := p.TypesInfo.Defs[fd.Name].(*types.Func)
+				if !ok {
+					continue
+				}
+				c := &candidate{
+					pkg: p, file: f, decl: fd, obj: obj,
+					target: &Target{
+						Name:      declName(fd),
+						Pos:       fset.Position(fd.Name.Pos()),
+						NumParams: n,
+					},
+					qualByFile: map[string]string{},
+				}
+				cands = append(cands, c)
+			}
+		}
+	})
+	sort.Slice(cands, func(i, j int) bool {
+		return cands[i].target.Pos.String() < cands[j].target.Pos.String()
+	})
+
+	// ---- Pass 3: gate and plan each candidate ------------------------
+	fileByName := map[string]*fileInfo{}
+	for _, fi := range files {
+		fileByName[fi.filename] = fi
+	}
+	src := func(filename string) ([]byte, error) {
+		fi := fileByName[filename]
+		if fi.src == nil {
+			b, err := readFile(filename)
+			if err != nil {
+				return nil, err
+			}
+			fi.src = b
+		}
+		return fi.src, nil
+	}
+
+	for _, c := range cands {
+		fi := fileByName[fset.Position(c.decl.Name.Pos()).Filename]
+		if fi != nil && fi.suppress.ignored(fset, c.decl.Name.Pos()) {
+			continue // suppressed: not even diagnosed
+		}
+		reason := c.plan(fset, ifaces, refsByPos, reserved, src)
+		if reason != "" {
+			c.target.SkipReason = reason
+			res.Skipped = append(res.Skipped, c.target)
+			continue
+		}
+		if err := c.emit(fset, refsByPos, res, src); err != nil {
+			return nil, err
+		}
+		res.Rewritten = append(res.Rewritten, c.target)
+	}
+
+	dedupEdits(res.Edits)
+	return res, nil
+}
+
+// plan runs the safety gates and fills in the candidate's rewrite plan,
+// returning a skip reason or "".
+func (c *candidate) plan(fset *token.FileSet, ifaces []*types.Interface, refsByPos map[token.Pos][]refInfo, reserved map[*types.Package]map[string]bool, src func(string) ([]byte, error)) string {
+	fd := c.decl
+	sig := c.obj.Signature()
+
+	if fd.Type.TypeParams != nil || (fd.Recv != nil && recvHasTypeParams(fd.Recv)) {
+		return "generic function"
+	}
+	if sig.Variadic() {
+		return "variadic parameters"
+	}
+	if hasCompilerDirective(fd.Doc) {
+		return "carries a //go: or //export directive"
+	}
+
+	// Parameters: split off a leading context.Context, require names.
+	params := flattenParams(fd.Type.Params)
+	if len(params) == 0 {
+		return "unnamed parameters"
+	}
+	start := 0
+	if isContextParam(c.pkg, params[0]) {
+		c.hasCtx = true
+		start = 1
+	}
+	fieldNames := map[string]bool{}
+	for _, p := range params[start:] {
+		if p.name == nil || p.name.Name == "_" || p.name.Name == "" {
+			return "blank or unnamed parameter"
+		}
+		fn := fieldName(p.name.Name)
+		if fieldNames[fn] {
+			return fmt.Sprintf("parameters %q collide as field %s", p.name.Name, fn)
+		}
+		fieldNames[fn] = true
+		text, err := nodeText(fset, src, p.typ)
+		if err != nil {
+			return "unreadable source"
+		}
+		obj := c.pkg.TypesInfo.Defs[p.name]
+		c.fields = append(c.fields, field{name: fn, typeText: text, objs: []types.Object{obj}})
+	}
+	if len(c.fields) == 0 {
+		return "nothing to group"
+	}
+
+	// Interface gate for methods.
+	if fd.Recv != nil {
+		recvT := sig.Recv().Type()
+		for _, intf := range ifaces {
+			if intf.NumMethods() == 0 {
+				continue
+			}
+			if m := findIfaceMethod(intf, c.obj.Name()); m != nil {
+				if types.Implements(recvT, intf) || types.Implements(types.NewPointer(recvT), intf) {
+					return "satisfies an interface"
+				}
+			}
+		}
+	}
+
+	// Reference gates.
+	refs := refsByPos[c.obj.Pos()]
+	for _, ref := range refs {
+		if ref.call == nil {
+			return "used as a function value"
+		}
+		if ref.generated {
+			return "called from generated code"
+		}
+		nargs := len(ref.call.Args)
+		if c.hasCtx {
+			nargs--
+		}
+		if nargs != len(c.fields) {
+			return "caller passes a multi-value call"
+		}
+	}
+
+	// Struct name (per-package uniqueness).
+	pkgReserved := reserved[c.pkg.Types]
+	if pkgReserved == nil {
+		pkgReserved = map[string]bool{}
+		reserved[c.pkg.Types] = pkgReserved
+	}
+	base := c.obj.Name()
+	name := base + "Params"
+	if taken(c.pkg, pkgReserved, name) && fd.Recv != nil {
+		name = recvTypeName(fd.Recv) + upperFirst(base) + "Params"
+	}
+	if taken(c.pkg, pkgReserved, name) {
+		return fmt.Sprintf("struct name %s already taken", name)
+	}
+	pkgReserved[name] = true
+	c.structName = name
+	c.target.StructName = name
+
+	// Qualifier per caller file (methods may be called from files that
+	// don't import the defining package).
+	for _, ref := range refs {
+		qual, ok := qualifierFor(ref, c.pkg)
+		if !ok {
+			return "caller file does not import the defining package"
+		}
+		c.qualByFile[ref.filename] = qual
+	}
+
+	// A param reused on the left of := (legal: it becomes an assignment)
+	// cannot be rewritten to a selector — arg.X, err := ... is invalid.
+	paramObjs := map[types.Object]bool{}
+	for _, f := range c.fields {
+		for _, o := range f.objs {
+			paramObjs[o] = true
+		}
+	}
+	reassigned := false
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		as, ok := n.(*ast.AssignStmt)
+		if !ok || as.Tok != token.DEFINE {
+			return true
+		}
+		for _, lhs := range as.Lhs {
+			if id, ok := lhs.(*ast.Ident); ok && paramObjs[c.pkg.TypesInfo.Uses[id]] {
+				reassigned = true
+			}
+		}
+		return true
+	})
+	if reassigned {
+		return "parameter reassigned with :="
+	}
+
+	// Argument name that collides with nothing in the function.
+	used := map[string]bool{}
+	ast.Inspect(fd, func(n ast.Node) bool {
+		if id, ok := n.(*ast.Ident); ok {
+			used[id.Name] = true
+		}
+		return true
+	})
+	c.argName = "arg"
+	for i := 0; used[c.argName]; i++ {
+		c.argName = fmt.Sprintf("arg%d", i)
+	}
+	return ""
+}
+
+// emit produces the edits for a planned candidate.
+func (c *candidate) emit(fset *token.FileSet, refsByPos map[token.Pos][]refInfo, res *Result, src func(string) ([]byte, error)) error {
+	fd := c.decl
+	declFile := fset.Position(fd.Name.Pos()).Filename
+	add := func(filename string, e Edit) {
+		res.Edits[filename] = append(res.Edits[filename], e)
+	}
+	off := func(p token.Pos) int { return fset.Position(p).Offset }
+
+	// 1. Struct declaration above the function (above its doc comment).
+	var b strings.Builder
+	fmt.Fprintf(&b, "// %s bundles the parameters of %s.\ntype %s struct {\n", c.structName, c.target.Name, c.structName)
+	for _, f := range c.fields {
+		fmt.Fprintf(&b, "\t%s %s\n", f.name, f.typeText)
+	}
+	b.WriteString("}\n\n")
+	insertAt := fd.Pos()
+	if fd.Doc != nil {
+		insertAt = fd.Doc.Pos()
+	}
+	add(declFile, Edit{Start: off(insertAt), End: off(insertAt), Text: b.String()})
+
+	// 2. Parameter list: replace everything after ctx with "arg Struct".
+	params := flattenParams(fd.Type.Params)
+	first := 0
+	if c.hasCtx {
+		first = 1
+	}
+	pstart := params[first].fieldStart
+	pend := fd.Type.Params.Closing
+	add(declFile, Edit{Start: off(pstart), End: off(pend), Text: c.argName + " " + c.structName})
+
+	// 3. Body: param uses become arg.Field.
+	paramObj := map[types.Object]string{}
+	for _, f := range c.fields {
+		for _, o := range f.objs {
+			paramObj[o] = f.name
+		}
+	}
+	ast.Inspect(fd.Body, func(n ast.Node) bool {
+		id, ok := n.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		if fname, ok := paramObj[c.pkg.TypesInfo.Uses[id]]; ok {
+			add(declFile, Edit{Start: off(id.Pos()), End: off(id.End()), Text: c.argName + "." + fname})
+		}
+		return true
+	})
+
+	// 4. Call sites: pure insertions around the existing arguments.
+	for _, ref := range refsByPos[c.obj.Pos()] {
+		call := ref.call
+		args := call.Args
+		if c.hasCtx {
+			args = args[1:]
+		}
+		qual := c.qualByFile[ref.filename]
+		add(ref.filename, Edit{
+			Start: off(args[0].Pos()), End: off(args[0].Pos()),
+			Text: qual + c.structName + "{" + c.fields[0].name + ": ",
+		})
+		for k := 1; k < len(args); k++ {
+			add(ref.filename, Edit{
+				Start: off(args[k].Pos()), End: off(args[k].Pos()),
+				Text: c.fields[k].name + ": ",
+			})
+		}
+		last := args[len(args)-1]
+		add(ref.filename, Edit{Start: off(last.End()), End: off(last.End()), Text: "}"})
+		c.target.NumCallers++
+	}
+	return nil
+}
+
+// ---- helpers ----------------------------------------------------------
+
+type param struct {
+	name       *ast.Ident
+	typ        ast.Expr
+	fieldStart token.Pos // start of the *ast.Field this param belongs to
+}
+
+func flattenParams(fl *ast.FieldList) []param {
+	var out []param
+	if fl == nil {
+		return out
+	}
+	for _, f := range fl.List {
+		if len(f.Names) == 0 {
+			out = append(out, param{name: nil, typ: f.Type, fieldStart: f.Pos()})
+			continue
+		}
+		for _, n := range f.Names {
+			out = append(out, param{name: n, typ: f.Type, fieldStart: f.Pos()})
+		}
+	}
+	return out
+}
+
+func paramCount(fl *ast.FieldList) int {
+	n := 0
+	for _, p := range flattenParams(fl) {
+		_ = p
+		n++
+	}
+	return n
+}
+
+func declName(fd *ast.FuncDecl) string {
+	if fd.Recv != nil {
+		return recvTypeName(fd.Recv) + "." + fd.Name.Name
+	}
+	return fd.Name.Name
+}
+
+func recvTypeName(recv *ast.FieldList) string {
+	if len(recv.List) == 0 {
+		return ""
+	}
+	t := recv.List[0].Type
+	for {
+		switch tt := t.(type) {
+		case *ast.StarExpr:
+			t = tt.X
+		case *ast.IndexExpr:
+			t = tt.X
+		case *ast.IndexListExpr:
+			t = tt.X
+		case *ast.Ident:
+			return tt.Name
+		default:
+			return ""
+		}
+	}
+}
+
+func recvHasTypeParams(recv *ast.FieldList) bool {
+	if len(recv.List) == 0 {
+		return false
+	}
+	switch recv.List[0].Type.(type) {
+	case *ast.IndexExpr, *ast.IndexListExpr:
+		return true
+	}
+	if st, ok := recv.List[0].Type.(*ast.StarExpr); ok {
+		switch st.X.(type) {
+		case *ast.IndexExpr, *ast.IndexListExpr:
+			return true
+		}
+	}
+	return false
+}
+
+func isContextParam(p *packages.Package, pr param) bool {
+	if pr.typ == nil {
+		return false
+	}
+	t := p.TypesInfo.TypeOf(pr.typ)
+	return t != nil && t.String() == "context.Context"
+}
+
+func hasCompilerDirective(doc *ast.CommentGroup) bool {
+	if doc == nil {
+		return false
+	}
+	for _, cm := range doc.List {
+		if strings.HasPrefix(cm.Text, "//go:") || strings.HasPrefix(cm.Text, "//export ") || cm.Text == "//export" {
+			return true
+		}
+	}
+	return false
+}
+
+func findIfaceMethod(intf *types.Interface, name string) *types.Func {
+	for i := range intf.NumMethods() {
+		if m := intf.Method(i); m.Name() == name {
+			return m
+		}
+	}
+	return nil
+}
+
+func taken(p *packages.Package, reserved map[string]bool, name string) bool {
+	return reserved[name] || p.Types.Scope().Lookup(name) != nil
+}
+
+func qualifierFor(ref refInfo, target *packages.Package) (string, bool) {
+	if ref.pkg.Types == target.Types || samePath(ref.pkg, target) {
+		return "", true
+	}
+	// Prefer the qualifier already used by the call expression.
+	if sel, ok := ref.call.Fun.(*ast.SelectorExpr); ok {
+		if x, ok := sel.X.(*ast.Ident); ok {
+			if _, isPkg := ref.pkg.TypesInfo.Uses[x].(*types.PkgName); isPkg {
+				return x.Name + ".", true
+			}
+		}
+	}
+	// Method call: find an existing import of the defining package.
+	for _, imp := range ref.file.Imports {
+		path := strings.Trim(imp.Path.Value, `"`)
+		if path != target.PkgPath {
+			continue
+		}
+		if imp.Name != nil {
+			switch imp.Name.Name {
+			case "_":
+				continue
+			case ".":
+				return "", true
+			default:
+				return imp.Name.Name + ".", true
+			}
+		}
+		return target.Types.Name() + ".", true
+	}
+	return "", false
+}
+
+func samePath(a, b *packages.Package) bool {
+	// Test variants share the path but not the *types.Package.
+	return strings.TrimSuffix(a.PkgPath, "_test") == b.PkgPath
+}
+
+var initialisms = map[string]string{
+	"id": "ID", "ids": "IDs", "url": "URL", "uri": "URI", "api": "API",
+	"http": "HTTP", "https": "HTTPS", "json": "JSON", "xml": "XML",
+	"sql": "SQL", "db": "DB", "uid": "UID", "ip": "IP", "ttl": "TTL",
+	"acl": "ACL", "cpu": "CPU", "ram": "RAM", "os": "OS", "ok": "OK",
+}
+
+func fieldName(param string) string {
+	if up, ok := initialisms[strings.ToLower(param)]; ok {
+		return up
+	}
+	return upperFirst(param)
+}
+
+func upperFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+func nodeText(fset *token.FileSet, src func(string) ([]byte, error), n ast.Node) (string, error) {
+	pos := fset.Position(n.Pos())
+	end := fset.Position(n.End())
+	b, err := src(pos.Filename)
+	if err != nil {
+		return "", err
+	}
+	return string(b[pos.Offset:end.Offset]), nil
+}
+
+func forEachPkg(pkgs []*packages.Package, fn func(*packages.Package)) {
+	seen := map[string]bool{}
+	var visit func(p *packages.Package)
+	visit = func(p *packages.Package) {
+		if seen[p.ID] {
+			return
+		}
+		seen[p.ID] = true
+		fn(p)
+	}
+	for _, p := range pkgs {
+		visit(p)
+	}
+}
+
+func dedupEdits(edits map[string][]Edit) {
+	for f, es := range edits {
+		seen := map[Edit]bool{}
+		out := es[:0]
+		for _, e := range es {
+			if !seen[e] {
+				seen[e] = true
+				out = append(out, e)
+			}
+		}
+		edits[f] = out
+	}
+}
+
+// Apply applies edits to src (sorted descending by Start; insertions at the
+// same offset keep their emit order).
+func Apply(src []byte, edits []Edit) []byte {
+	sort.SliceStable(edits, func(i, j int) bool {
+		if edits[i].Start != edits[j].Start {
+			return edits[i].Start > edits[j].Start
+		}
+		return edits[i].End > edits[j].End
+	})
+	out := src
+	for _, e := range edits {
+		out = append(out[:e.Start:e.Start], append([]byte(e.Text), out[e.End:]...)...)
+	}
+	return out
+}

--- a/structify/structify.go
+++ b/structify/structify.go
@@ -766,8 +766,11 @@ func qualifierFor(ref refInfo, target *packages.Package) (string, bool) {
 }
 
 func samePath(a, b *packages.Package) bool {
-	// Test variants share the path but not the *types.Package.
-	return strings.TrimSuffix(a.PkgPath, "_test") == b.PkgPath
+	// The in-package test variant ("p [p.test]") shares PkgPath with the
+	// primary package but not its *types.Package. The EXTERNAL test
+	// package ("p_test") is a different package — it needs a qualifier,
+	// so it must NOT match here (it falls through to the import scan).
+	return a.PkgPath == b.PkgPath
 }
 
 var initialisms = map[string]string{

--- a/structify/structify.go
+++ b/structify/structify.go
@@ -17,7 +17,9 @@
 //	func CreateUser(ctx context.Context, arg CreateUserParams) error
 //
 // with every call site rewritten to CreateUser(ctx, CreateUserParams{Name: …}).
-// A leading context.Context parameter stays positional, per Go convention.
+// A context.Context parameter stays positional, per Go convention — and if
+// it isn't the first parameter, it is REORDERED to the front as part of the
+// rewrite (callers' ctx arguments move with it).
 //
 // Because a signature change is only safe when every reference is visible
 // and rewritable, a function is SKIPPED (diagnosed, not rewritten) when it:
@@ -28,6 +30,9 @@
 //   - has callers in generated files (regeneration would break the build)
 //   - has a caller passing a multi-value call f(g()) or missing an import
 //     needed to name the params struct
+//   - has multiple context.Context parameters, or (when hoisting a
+//     non-leading ctx) a call site whose ctx argument references a
+//     parameter being rewritten
 //   - carries a //go:* or //export directive
 //   - is suppressed with "//lint:ignore structify" (or the funcparamlint
 //     spelling) or "structify:ignore"
@@ -111,11 +116,13 @@ type candidate struct {
 	obj    *types.Func
 	target *Target
 
-	hasCtx     bool
-	fields     []field
-	argName    string
-	structName string
-	qualByFile map[string]string // filename -> qualifier ("", "pkg.")
+	ctxIndex    int    // index of the context.Context param, -1 if none
+	ctxName     string // its name ("_" when blank/unnamed)
+	ctxTypeText string // its type as written in source
+	fields      []field
+	argName     string
+	structName  string
+	qualByFile  map[string]string // filename -> qualifier ("", "pkg.")
 }
 
 // refInfo is one identifier reference to a function object.
@@ -242,7 +249,7 @@ func Plan(pkgs []*packages.Package, cfg Config) (*Result, error) {
 					continue
 				}
 				c := &candidate{
-					pkg: p, file: f, decl: fd, obj: obj,
+					pkg: p, file: f, decl: fd, obj: obj, ctxIndex: -1,
 					target: &Target{
 						Name:      declName(fd),
 						Pos:       fset.Position(fd.Name.Pos()),
@@ -275,12 +282,26 @@ func Plan(pkgs []*packages.Package, cfg Config) (*Result, error) {
 		return fi.src, nil
 	}
 
+	// Params that will be renamed to arg.Field by ANY candidate: a ctx
+	// argument expression that references one cannot be moved textually.
+	renamed := map[types.Object]bool{}
+	for _, c := range cands {
+		for _, p := range flattenParams(c.decl.Type.Params) {
+			if p.name == nil || p.name.Name == "_" || isContextParam(c.pkg, p) {
+				continue
+			}
+			if o := c.pkg.TypesInfo.Defs[p.name]; o != nil {
+				renamed[o] = true
+			}
+		}
+	}
+
 	for _, c := range cands {
 		fi := fileByName[fset.Position(c.decl.Name.Pos()).Filename]
 		if fi != nil && fi.suppress.ignored(fset, c.decl.Name.Pos()) {
 			continue // suppressed: not even diagnosed
 		}
-		reason := c.plan(fset, ifaces, refsByPos, reserved, src)
+		reason := c.plan(fset, ifaces, refsByPos, reserved, renamed, src)
 		if reason != "" {
 			c.target.SkipReason = reason
 			res.Skipped = append(res.Skipped, c.target)
@@ -298,7 +319,7 @@ func Plan(pkgs []*packages.Package, cfg Config) (*Result, error) {
 
 // plan runs the safety gates and fills in the candidate's rewrite plan,
 // returning a skip reason or "".
-func (c *candidate) plan(fset *token.FileSet, ifaces []*types.Interface, refsByPos map[token.Pos][]refInfo, reserved map[*types.Package]map[string]bool, src func(string) ([]byte, error)) string {
+func (c *candidate) plan(fset *token.FileSet, ifaces []*types.Interface, refsByPos map[token.Pos][]refInfo, reserved map[*types.Package]map[string]bool, renamed map[types.Object]bool, src func(string) ([]byte, error)) string {
 	fd := c.decl
 	sig := c.obj.Signature()
 
@@ -312,26 +333,37 @@ func (c *candidate) plan(fset *token.FileSet, ifaces []*types.Interface, refsByP
 		return "carries a //go: or //export directive"
 	}
 
-	// Parameters: split off a leading context.Context, require names.
+	// Parameters. A context.Context stays positional: leading stays put,
+	// non-leading is reordered to the front as part of the rewrite. It
+	// never becomes a struct field (per the context package docs).
 	params := flattenParams(fd.Type.Params)
 	if len(params) == 0 {
 		return "unnamed parameters"
 	}
-	start := 0
-	if isContextParam(c.pkg, params[0]) {
-		c.hasCtx = true
-		start = 1
+	for i, p := range params {
+		if isContextParam(c.pkg, p) {
+			if c.ctxIndex >= 0 {
+				return "multiple context.Context parameters"
+			}
+			c.ctxIndex = i
+			c.ctxName = "_"
+			if p.name != nil && p.name.Name != "" {
+				c.ctxName = p.name.Name
+			}
+			text, err := nodeText(fset, src, p.typ)
+			if err != nil {
+				return "unreadable source"
+			}
+			c.ctxTypeText = text
+		}
 	}
 	fieldNames := map[string]bool{}
-	for _, p := range params[start:] {
+	for i, p := range params {
+		if i == c.ctxIndex {
+			continue
+		}
 		if p.name == nil || p.name.Name == "_" || p.name.Name == "" {
 			return "blank or unnamed parameter"
-		}
-		// A context belongs in the leading position, never in a struct
-		// field (per context package docs). Reorder the params by hand,
-		// then structify keeps it positional.
-		if isContextParam(c.pkg, p) {
-			return "context.Context parameter not in leading position"
 		}
 		fn := fieldName(p.name.Name)
 		if fieldNames[fn] {
@@ -374,11 +406,25 @@ func (c *candidate) plan(fset *token.FileSet, ifaces []*types.Interface, refsByP
 			return "called from generated code"
 		}
 		nargs := len(ref.call.Args)
-		if c.hasCtx {
+		if c.ctxIndex >= 0 {
 			nargs--
 		}
 		if nargs != len(c.fields) {
 			return "caller passes a multi-value call"
+		}
+		// Reordering ctx to the front moves its argument text; that text
+		// must not contain an identifier some rewrite renames to arg.X.
+		if c.ctxIndex > 0 {
+			bad := false
+			ast.Inspect(ref.call.Args[c.ctxIndex], func(n ast.Node) bool {
+				if id, ok := n.(*ast.Ident); ok && renamed[ref.pkg.TypesInfo.Uses[id]] {
+					bad = true
+				}
+				return !bad
+			})
+			if bad {
+				return "context argument at a call site references a parameter being rewritten"
+			}
 		}
 	}
 
@@ -472,15 +518,23 @@ func (c *candidate) emit(fset *token.FileSet, refsByPos map[token.Pos][]refInfo,
 	}
 	add(declFile, Edit{Start: off(insertAt), End: off(insertAt), Text: b.String()})
 
-	// 2. Parameter list: replace everything after ctx with "arg Struct".
+	// 2. Parameter list. Leading (or absent) ctx: replace everything
+	// after it with "arg Struct". Non-leading ctx: rewrite the whole
+	// list, hoisting ctx to the front.
 	params := flattenParams(fd.Type.Params)
-	first := 0
-	if c.hasCtx {
-		first = 1
-	}
-	pstart := params[first].fieldStart
 	pend := fd.Type.Params.Closing
-	add(declFile, Edit{Start: off(pstart), End: off(pend), Text: c.argName + " " + c.structName})
+	if c.ctxIndex <= 0 {
+		first := 0
+		if c.ctxIndex == 0 {
+			first = 1
+		}
+		pstart := params[first].fieldStart
+		add(declFile, Edit{Start: off(pstart), End: off(pend), Text: c.argName + " " + c.structName})
+	} else {
+		pstart := params[0].fieldStart
+		text := c.ctxName + " " + c.ctxTypeText + ", " + c.argName + " " + c.structName
+		add(declFile, Edit{Start: off(pstart), End: off(pend), Text: text})
+	}
 
 	// 3. Body: param uses become arg.Field.
 	paramObj := map[types.Object]string{}
@@ -500,18 +554,37 @@ func (c *candidate) emit(fset *token.FileSet, refsByPos map[token.Pos][]refInfo,
 		return true
 	})
 
-	// 4. Call sites: pure insertions around the existing arguments.
+	// 4. Call sites. With ctx leading or absent these are pure insertions
+	// around the existing arguments. With a hoisted ctx, its argument text
+	// additionally moves to the front (safe: the gate above proved it
+	// contains nothing being renamed).
 	for _, ref := range refsByPos[c.obj.Pos()] {
 		call := ref.call
 		args := call.Args
-		if c.hasCtx {
+		qual := c.qualByFile[ref.filename]
+
+		open := qual + c.structName + "{" + c.fields[0].name + ": "
+		if c.ctxIndex > 0 {
+			ctxArg := args[c.ctxIndex]
+			ctxText, err := nodeText(fset, src, ctxArg)
+			if err != nil {
+				return err
+			}
+			// Move: prepend ctx before the first argument, delete it
+			// (and its preceding separator) from its old spot.
+			open = ctxText + ", " + open
+			add(ref.filename, Edit{
+				Start: off(args[c.ctxIndex-1].End()), End: off(ctxArg.End()),
+			})
+			rest := make([]ast.Expr, 0, len(args)-1)
+			rest = append(rest, args[:c.ctxIndex]...)
+			rest = append(rest, args[c.ctxIndex+1:]...)
+			args = rest
+		} else if c.ctxIndex == 0 {
 			args = args[1:]
 		}
-		qual := c.qualByFile[ref.filename]
-		add(ref.filename, Edit{
-			Start: off(args[0].Pos()), End: off(args[0].Pos()),
-			Text: qual + c.structName + "{" + c.fields[0].name + ": ",
-		})
+
+		add(ref.filename, Edit{Start: off(args[0].Pos()), End: off(args[0].Pos()), Text: open})
 		for k := 1; k < len(args); k++ {
 			add(ref.filename, Edit{
 				Start: off(args[k].Pos()), End: off(args[k].Pos()),

--- a/structify/structify.go
+++ b/structify/structify.go
@@ -31,8 +31,10 @@
 //   - has a caller passing a multi-value call f(g()) or missing an import
 //     needed to name the params struct
 //   - has multiple context.Context parameters, or (when hoisting a
-//     non-leading ctx) a call site whose ctx argument references a
-//     parameter being rewritten
+//     non-leading ctx) a call site where the move could be observable:
+//     the ctx argument references a parameter being rewritten, is not a
+//     bare ident or context.Background()/TODO(), or follows an argument
+//     with side effects (evaluation order must be preserved)
 //   - carries a //go:* or //export directive
 //   - is suppressed with "//lint:ignore structify" (or the funcparamlint
 //     spelling) or "structify:ignore"
@@ -447,6 +449,20 @@ func (c *candidate) plan(fset *token.FileSet, ifaces []*types.Interface, refsByP
 			if bad {
 				return "context argument at a call site references a parameter being rewritten"
 			}
+			// Hoisting also moves the ctx EVALUATION ahead of the args
+			// that preceded it. That is only unobservable when the ctx
+			// expression itself is effect- and panic-free (a bare ident,
+			// or context.Background()/TODO()) and nothing before it can
+			// produce effects or mutate what the ctx expression reads
+			// (no calls, receives, or closures among earlier args).
+			if !safeCtxExpr(ref.pkg, ref.call.Args[c.ctxIndex]) {
+				return "hoisting ctx would change argument evaluation order (ctx argument is not a plain ident or context.Background/TODO)"
+			}
+			for _, prev := range ref.call.Args[:c.ctxIndex] {
+				if !effectFree(ref.pkg, prev) {
+					return "hoisting ctx would change argument evaluation order (effectful argument before ctx at a call site)"
+				}
+			}
 		}
 	}
 
@@ -763,6 +779,53 @@ func qualifierFor(ref refInfo, target *packages.Package) (string, bool) {
 		return target.Types.Name() + ".", true
 	}
 	return "", false
+}
+
+// safeCtxExpr reports whether evaluating expr early is unobservable: a
+// bare identifier (no effects, cannot panic) or one of the well-known
+// pure constructors context.Background() / context.TODO().
+func safeCtxExpr(p *packages.Package, expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return true
+	case *ast.CallExpr:
+		sel, ok := e.Fun.(*ast.SelectorExpr)
+		if !ok || len(e.Args) != 0 {
+			return false
+		}
+		fn, ok := p.TypesInfo.Uses[sel.Sel].(*types.Func)
+		if !ok || fn.Pkg() == nil {
+			return false
+		}
+		return fn.Pkg().Path() == "context" && (fn.Name() == "Background" || fn.Name() == "TODO")
+	default:
+		return false
+	}
+}
+
+// effectFree reports whether expr can neither produce side effects nor
+// mutate variables: no function calls (type conversions are fine), no
+// channel receives, no function literals. Such expressions may still
+// panic, but reordering a safeCtxExpr around them is unobservable.
+func effectFree(p *packages.Package, expr ast.Expr) bool {
+	free := true
+	ast.Inspect(expr, func(n ast.Node) bool {
+		switch e := n.(type) {
+		case *ast.CallExpr:
+			// A conversion (T(x)) has no observable effects; a call does.
+			if tv, ok := p.TypesInfo.Types[e.Fun]; !ok || !tv.IsType() {
+				free = false
+			}
+		case *ast.UnaryExpr:
+			if e.Op == token.ARROW {
+				free = false
+			}
+		case *ast.FuncLit:
+			free = false
+		}
+		return free
+	})
+	return free
 }
 
 func samePath(a, b *packages.Package) bool {

--- a/structify/structify.go
+++ b/structify/structify.go
@@ -43,11 +43,12 @@
 package structify
 
 import (
+	"cmp"
 	"fmt"
 	"go/ast"
 	"go/token"
 	"go/types"
-	"sort"
+	"slices"
 	"strings"
 
 	"golang.org/x/tools/go/packages"
@@ -159,6 +160,7 @@ func Plan(pkgs []*packages.Package, cfg Config) (*Result, error) {
 	callee := map[*ast.Ident]*ast.CallExpr{}
 	// refs by target key (position of the object's declaration)
 	refsByPos := map[token.Pos][]refInfo{}
+	seenRef := map[[2]token.Pos]bool{}
 	// interface method names -> interfaces (for the implements gate)
 	var ifaces []*types.Interface
 
@@ -186,19 +188,35 @@ func Plan(pkgs []*packages.Package, cfg Config) (*Result, error) {
 				}
 				return true
 			})
-			for ident, obj := range p.TypesInfo.Uses {
-				fn, ok := obj.(*types.Func)
-				if !ok || fn.Pos() == token.NoPos {
-					continue
-				}
-				if fset.File(ident.Pos()) == nil || fset.Position(ident.Pos()).Filename != filename {
-					continue
-				}
-				refsByPos[fn.Pos()] = append(refsByPos[fn.Pos()], refInfo{
-					pkg: p, file: f, filename: filename, ident: ident,
-					call: callee[ident], generated: fi.generated,
-				})
+		}
+		// One Uses pass per package (not per file). With Tests:true the
+		// same non-test file is type-checked again in the test variant;
+		// dedupe refs by position so call sites are counted once.
+		genByName := map[string]bool{}
+		fileNodeByName := map[string]*ast.File{}
+		for i, f := range p.Syntax {
+			genByName[p.CompiledGoFiles[i]] = ast.IsGenerated(f)
+			fileNodeByName[p.CompiledGoFiles[i]] = f
+		}
+		for ident, obj := range p.TypesInfo.Uses {
+			fn, ok := obj.(*types.Func)
+			if !ok || fn.Pos() == token.NoPos || fset.File(ident.Pos()) == nil {
+				continue
 			}
+			filename := fset.Position(ident.Pos()).Filename
+			f, ok := fileNodeByName[filename]
+			if !ok {
+				continue
+			}
+			key := [2]token.Pos{fn.Pos(), ident.Pos()}
+			if seenRef[key] {
+				continue
+			}
+			seenRef[key] = true
+			refsByPos[fn.Pos()] = append(refsByPos[fn.Pos()], refInfo{
+				pkg: p, file: f, filename: filename, ident: ident,
+				call: callee[ident], generated: genByName[filename],
+			})
 		}
 		// Collect interfaces for the implements gate.
 		scope := p.Types.Scope()
@@ -261,8 +279,12 @@ func Plan(pkgs []*packages.Package, cfg Config) (*Result, error) {
 			}
 		}
 	})
-	sort.Slice(cands, func(i, j int) bool {
-		return cands[i].target.Pos.String() < cands[j].target.Pos.String()
+	slices.SortFunc(cands, func(a, b *candidate) int {
+		return cmp.Or(
+			strings.Compare(a.target.Pos.Filename, b.target.Pos.Filename),
+			cmp.Compare(a.target.Pos.Line, b.target.Pos.Line),
+			cmp.Compare(a.target.Pos.Column, b.target.Pos.Column),
+		)
 	})
 
 	// ---- Pass 3: gate and plan each candidate ------------------------
@@ -811,11 +833,8 @@ func dedupEdits(edits map[string][]Edit) {
 // Apply applies edits to src (sorted descending by Start; insertions at the
 // same offset keep their emit order).
 func Apply(src []byte, edits []Edit) []byte {
-	sort.SliceStable(edits, func(i, j int) bool {
-		if edits[i].Start != edits[j].Start {
-			return edits[i].Start > edits[j].Start
-		}
-		return edits[i].End > edits[j].End
+	slices.SortStableFunc(edits, func(a, b Edit) int {
+		return cmp.Or(cmp.Compare(b.Start, a.Start), cmp.Compare(b.End, a.End))
 	})
 	out := src
 	for _, e := range edits {

--- a/structify/structify_test.go
+++ b/structify/structify_test.go
@@ -1,0 +1,495 @@
+package structify_test
+
+import (
+	"fmt"
+	"go/format"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/omniaura/go-kit/structify"
+	"golang.org/x/tools/go/packages"
+)
+
+// loadModule writes files into a temp module and loads it.
+func loadModule(t *testing.T, files map[string]string) (string, []*packages.Package) {
+	t.Helper()
+	dir := t.TempDir()
+	files["go.mod"] = "module example.com/m\n\ngo 1.25\n"
+	for name, content := range files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir, load(t, dir)
+}
+
+func load(t *testing.T, dir string) []*packages.Package {
+	t.Helper()
+	cfg := &packages.Config{
+		Dir: dir,
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles |
+			packages.NeedImports | packages.NeedDeps | packages.NeedTypes |
+			packages.NeedSyntax | packages.NeedTypesInfo,
+		Tests: true,
+		Env:   append(os.Environ(), "GOWORK=off", "GOFLAGS=-mod=mod", "GOPROXY=off"),
+	}
+	pkgs, err := packages.Load(cfg, "./...")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if packages.PrintErrors(pkgs) > 0 {
+		t.Fatal("test module has errors before rewrite")
+	}
+	return pkgs
+}
+
+// plan is a convenience wrapper.
+func plan(t *testing.T, pkgs []*packages.Package) *structify.Result {
+	t.Helper()
+	res, err := structify.Plan(pkgs, structify.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return res
+}
+
+// applyAll writes the rewritten files back and returns their contents.
+// It fails the test if the rewritten module no longer type-checks —
+// the strongest guarantee a signature-changing refactor can offer.
+func applyAll(t *testing.T, dir string, res *structify.Result) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for filename, edits := range res.Edits {
+		src, err := os.ReadFile(filename)
+		if err != nil {
+			t.Fatal(err)
+		}
+		formatted, err := format.Source(structify.Apply(src, edits))
+		if err != nil {
+			t.Fatalf("gofmt after rewrite of %s: %v", filename, err)
+		}
+		if err := os.WriteFile(filename, formatted, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		rel, _ := filepath.Rel(dir, filename)
+		out[rel] = string(formatted)
+	}
+	// Reload: must type-check cleanly and be a fixpoint.
+	pkgs := load(t, dir)
+	again := plan(t, pkgs)
+	if len(again.Rewritten) != 0 {
+		t.Fatalf("not idempotent: second pass wants to rewrite %s", again.Rewritten[0].Name)
+	}
+	return out
+}
+
+func mustContain(t *testing.T, got, want string) {
+	t.Helper()
+	if !strings.Contains(got, want) {
+		t.Errorf("output missing %q:\n%s", want, got)
+	}
+}
+
+func TestFuncWithCtxAndCallers(t *testing.T) {
+	dir, pkgs := loadModule(t, map[string]string{
+		"a/a.go": `package a
+
+import "context"
+
+// CreateUser makes a user.
+func CreateUser(ctx context.Context, name, email string, age int, admin bool) string {
+	_ = ctx
+	if admin {
+		return name + email
+	}
+	return name
+}
+
+func caller(ctx context.Context) string {
+	return CreateUser(ctx, "n", "e", 41+1, true)
+}
+`,
+		"b/b.go": `package b
+
+import (
+	"context"
+
+	"example.com/m/a"
+)
+
+func Use() string {
+	return a.CreateUser(context.Background(), "x", "y", 7, false)
+}
+`,
+	})
+	res := plan(t, pkgs)
+	if len(res.Rewritten) != 1 || len(res.Skipped) != 0 {
+		t.Fatalf("rewritten=%d skipped=%d, want 1/0 (%+v)", len(res.Rewritten), len(res.Skipped), res.Skipped)
+	}
+	tgt := res.Rewritten[0]
+	if tgt.StructName != "CreateUserParams" || tgt.NumCallers != 2 {
+		t.Fatalf("target = %+v", tgt)
+	}
+	out := applyAll(t, dir, res)
+
+	a := out["a/a.go"]
+	mustContain(t, a, "// CreateUserParams bundles the parameters of CreateUser.")
+	mustContain(t, a, "type CreateUserParams struct {")
+	mustContain(t, a, "Name  string")
+	mustContain(t, a, "Admin bool")
+	mustContain(t, a, "func CreateUser(ctx context.Context, arg CreateUserParams) string {")
+	mustContain(t, a, "return arg.Name + arg.Email")
+	mustContain(t, a, `CreateUser(ctx, CreateUserParams{Name: "n", Email: "e", Age: 41 + 1, Admin: true})`)
+
+	b := out["b/b.go"]
+	mustContain(t, b, `a.CreateUser(context.Background(), a.CreateUserParams{Name: "x", Email: "y", Age: 7, Admin: false})`)
+}
+
+func TestMethodCrossPackageCaller(t *testing.T) {
+	dir, pkgs := loadModule(t, map[string]string{
+		"svc/svc.go": `package svc
+
+type Client struct{}
+
+func (c *Client) Upload(bucket, key, contentType string, size int64, public bool) error {
+	_ = bucket + key + contentType
+	_, _ = size, public
+	return nil
+}
+`,
+		"use/use.go": `package use
+
+import "example.com/m/svc"
+
+func Do(c *svc.Client) error {
+	return c.Upload("b", "k", "text/plain", 42, true)
+}
+`,
+	})
+	res := plan(t, pkgs)
+	if len(res.Rewritten) != 1 {
+		t.Fatalf("rewritten=%d skipped=%+v", len(res.Rewritten), res.Skipped)
+	}
+	out := applyAll(t, dir, res)
+	mustContain(t, out["svc/svc.go"], "func (c *Client) Upload(arg UploadParams) error {")
+	mustContain(t, out["use/use.go"], `c.Upload(svc.UploadParams{Bucket: "b", Key: "k", ContentType: "text/plain", Size: 42, Public: true})`)
+}
+
+func TestTestFileCallersRewritten(t *testing.T) {
+	dir, pkgs := loadModule(t, map[string]string{
+		"a/a.go": `package a
+
+func Sum(a1, a2, a3, a4, a5 int) int { return a1 + a2 + a3 + a4 + a5 }
+`,
+		"a/a_test.go": `package a
+
+import "testing"
+
+func TestSum(t *testing.T) {
+	if Sum(1, 2, 3, 4, 5) != 15 {
+		t.Fatal("nope")
+	}
+}
+`,
+	})
+	res := plan(t, pkgs)
+	if len(res.Rewritten) != 1 || res.Rewritten[0].NumCallers != 1 {
+		t.Fatalf("res=%+v skipped=%+v", res.Rewritten, res.Skipped)
+	}
+	out := applyAll(t, dir, res)
+	mustContain(t, out["a/a_test.go"], "Sum(SumParams{A1: 1, A2: 2, A3: 3, A4: 4, A5: 5})")
+}
+
+func TestNestedStructifiedCalls(t *testing.T) {
+	// outer's params are used as arguments to inner — the ident rewrites
+	// happen inside spans that the caller rewrite wraps with insertions.
+	dir, pkgs := loadModule(t, map[string]string{
+		"a/a.go": `package a
+
+func inner(p, q, r, s, u int) int { return p + q + r + s + u }
+
+func outer(v, w, x, y, z int) int {
+	return inner(v, w, x, y, z)
+}
+
+func kick() int { return outer(1, 2, 3, 4, 5) }
+`,
+	})
+	res := plan(t, pkgs)
+	if len(res.Rewritten) != 2 {
+		t.Fatalf("rewritten=%d skipped=%+v", len(res.Rewritten), res.Skipped)
+	}
+	out := applyAll(t, dir, res)
+	mustContain(t, out["a/a.go"], "return inner(innerParams{P: arg.V, Q: arg.W, R: arg.X, S: arg.Y, U: arg.Z})")
+	mustContain(t, out["a/a.go"], "outer(outerParams{V: 1, W: 2, X: 3, Y: 4, Z: 5})")
+}
+
+func TestBodyShadowingPreserved(t *testing.T) {
+	dir, pkgs := loadModule(t, map[string]string{
+		"a/a.go": `package a
+
+func F(name, email, city, zip, state string) string {
+	out := name
+	{
+		name := "shadow"
+		out += name
+	}
+	return out + email + city + zip + state
+}
+
+var _ = F("a", "b", "c", "d", "e")
+`,
+	})
+	res := plan(t, pkgs)
+	if len(res.Rewritten) != 1 {
+		t.Fatalf("skipped=%+v", res.Skipped)
+	}
+	out := applyAll(t, dir, res)
+	mustContain(t, out["a/a.go"], `name := "shadow"`)
+	mustContain(t, out["a/a.go"], "out += name") // shadowed use untouched
+	mustContain(t, out["a/a.go"], "out := arg.Name")
+}
+
+func TestInitialisms(t *testing.T) {
+	dir, pkgs := loadModule(t, map[string]string{
+		"a/a.go": `package a
+
+func Fetch(userID, url, id, apiKey, dbName string) string {
+	return userID + url + id + apiKey + dbName
+}
+
+var _ = Fetch("u", "l", "i", "k", "d")
+`,
+	})
+	res := plan(t, pkgs)
+	if len(res.Rewritten) != 1 {
+		t.Fatalf("skipped=%+v", res.Skipped)
+	}
+	out := applyAll(t, dir, res)
+	for _, want := range []string{"UserID", "URL", "ID", "ApiKey", "DbName"} {
+		if !regexp.MustCompile(`\t` + want + `\s+string`).MatchString(out["a/a.go"]) {
+			t.Errorf("missing field %s:\n%s", want, out["a/a.go"])
+		}
+	}
+}
+
+func TestStructNameCollisionUsesRecvPrefix(t *testing.T) {
+	dir, pkgs := loadModule(t, map[string]string{
+		"a/a.go": `package a
+
+// UploadParams is already taken.
+type UploadParams struct{ X int }
+
+type Store struct{}
+
+func (s *Store) Upload(bucket, key, kind string, size int64, public bool) error {
+	_ = bucket + key + kind
+	_, _ = size, public
+	return nil
+}
+
+var _ = (&Store{}).Upload("b", "k", "t", 1, true)
+`,
+	})
+	res := plan(t, pkgs)
+	if len(res.Rewritten) != 1 {
+		t.Fatalf("skipped=%+v", res.Skipped)
+	}
+	if got := res.Rewritten[0].StructName; got != "StoreUploadParams" {
+		t.Fatalf("StructName = %q, want StoreUploadParams", got)
+	}
+	applyAll(t, dir, res)
+}
+
+func TestSkips(t *testing.T) {
+	cases := []struct {
+		name   string
+		src    string
+		reason string
+	}{
+		{
+			name: "variadic",
+			src: `package a
+func F(a1, a2, a3, a4 int, rest ...int) int { return a1 + a2 + a3 + a4 + len(rest) }
+var _ = F(1, 2, 3, 4, 5)
+`,
+			reason: "variadic",
+		},
+		{
+			name: "func value",
+			src: `package a
+func F(a1, a2, a3, a4, a5 int) int { return a1 }
+var G = F
+`,
+			reason: "function value",
+		},
+		{
+			name: "interface method",
+			src: `package a
+type Uploader interface {
+	Upload(bucket, key, kind string, size int64, public bool) error
+}
+type S struct{}
+func (S) Upload(bucket, key, kind string, size int64, public bool) error { return nil }
+var _ Uploader = S{}
+`,
+			reason: "interface",
+		},
+		{
+			name: "multi-value call",
+			src: `package a
+func five() (int, int, int, int, int) { return 1, 2, 3, 4, 5 }
+func F(a1, a2, a3, a4, a5 int) int { return a1 }
+var _ = F(five())
+`,
+			reason: "multi-value",
+		},
+		{
+			name: "blank param",
+			src: `package a
+func F(a1, a2, a3, a4 int, _ string) int { return a1 }
+var _ = F(1, 2, 3, 4, "x")
+`,
+			reason: "blank",
+		},
+		{
+			name: "generic",
+			src: `package a
+func F[T any](a1, a2, a3, a4, a5 T) T { return a1 }
+var _ = F(1, 2, 3, 4, 5)
+`,
+			reason: "generic",
+		},
+		{
+			name: "param reused on := left side",
+			src: `package a
+func F(cfg, b, c, d, e string) (string, error) {
+	cfg, err := cfg+"x", error(nil)
+	return cfg + b + c + d + e, err
+}
+var _, _ = F("a", "b", "c", "d", "e")
+`,
+			reason: "reassigned with :=",
+		},
+		{
+			name: "compiler directive",
+			src: `package a
+//go:noinline
+func F(a1, a2, a3, a4, a5 int) int { return a1 }
+var _ = F(1, 2, 3, 4, 5)
+`,
+			reason: "directive",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, pkgs := loadModule(t, map[string]string{"a/a.go": tc.src})
+			res := plan(t, pkgs)
+			if len(res.Rewritten) != 0 {
+				t.Fatalf("expected skip, got rewrite %+v", res.Rewritten[0])
+			}
+			if len(res.Skipped) != 1 {
+				t.Fatalf("skipped=%d, want 1", len(res.Skipped))
+			}
+			if !strings.Contains(res.Skipped[0].SkipReason, tc.reason) {
+				t.Fatalf("reason %q does not mention %q", res.Skipped[0].SkipReason, tc.reason)
+			}
+			if len(res.Edits) != 0 {
+				t.Fatalf("skip must produce no edits, got %d files", len(res.Edits))
+			}
+		})
+	}
+}
+
+func TestSkipCallerInGeneratedFile(t *testing.T) {
+	_, pkgs := loadModule(t, map[string]string{
+		"a/a.go": `package a
+
+func F(a1, a2, a3, a4, a5 int) int { return a1 }
+`,
+		"a/gen.go": `// Code generated by testgen. DO NOT EDIT.
+
+package a
+
+var _ = F(1, 2, 3, 4, 5)
+`,
+	})
+	res := plan(t, pkgs)
+	if len(res.Rewritten) != 0 || len(res.Skipped) != 1 {
+		t.Fatalf("rewritten=%d skipped=%d", len(res.Rewritten), len(res.Skipped))
+	}
+	if !strings.Contains(res.Skipped[0].SkipReason, "generated") {
+		t.Fatalf("reason = %q", res.Skipped[0].SkipReason)
+	}
+}
+
+func TestSuppressionsBothSpellings(t *testing.T) {
+	_, pkgs := loadModule(t, map[string]string{
+		"a/a.go": `package a
+
+//lint:ignore funcparamlint legacy spelling
+func F(a1, a2, a3, a4, a5 int) int { return a1 }
+
+// structify:ignore native spelling
+func G(a1, a2, a3, a4, a5 int) int { return a1 }
+
+var _ = F(1, 2, 3, 4, 5)
+var _ = G(1, 2, 3, 4, 5)
+`,
+	})
+	res := plan(t, pkgs)
+	if len(res.Rewritten) != 0 || len(res.Skipped) != 0 {
+		t.Fatalf("suppressed funcs were processed: rewritten=%d skipped=%d", len(res.Rewritten), len(res.Skipped))
+	}
+}
+
+func TestArgNameAvoidsCollision(t *testing.T) {
+	dir, pkgs := loadModule(t, map[string]string{
+		"a/a.go": `package a
+
+func F(name, email, city, zip, state string) string {
+	arg := "local"
+	return arg + name + email + city + zip + state
+}
+
+var _ = F("a", "b", "c", "d", "e")
+`,
+	})
+	res := plan(t, pkgs)
+	if len(res.Rewritten) != 1 {
+		t.Fatalf("skipped=%+v", res.Skipped)
+	}
+	out := applyAll(t, dir, res)
+	mustContain(t, out["a/a.go"], "func F(arg0 FParams) string {")
+	mustContain(t, out["a/a.go"], `arg := "local"`)
+	mustContain(t, out["a/a.go"], "return arg + arg0.Name")
+}
+
+func TestReportTargetsWithoutFix(t *testing.T) {
+	_, pkgs := loadModule(t, map[string]string{
+		"a/a.go": `package a
+
+func F(a1, a2, a3, a4, a5 int) int { return a1 }
+var _ = F(1, 2, 3, 4, 5)
+`,
+	})
+	res := plan(t, pkgs)
+	if len(res.Rewritten) != 1 {
+		t.Fatal("expected one target")
+	}
+	tgt := res.Rewritten[0]
+	if tgt.NumParams != 5 || tgt.NumCallers != 1 || tgt.StructName != "FParams" {
+		t.Fatalf("target = %+v", tgt)
+	}
+	msg := fmt.Sprintf("%s: %d params -> %s", tgt.Name, tgt.NumParams, tgt.StructName)
+	if msg == "" {
+		t.Fatal("unreachable")
+	}
+}

--- a/structify/structify_test.go
+++ b/structify/structify_test.go
@@ -417,6 +417,40 @@ var _ = F(context.TODO(), "b", "c", "d", context.TODO())
 			reason: "multiple context.Context",
 		},
 		{
+			name: "effectful arg before hoisted ctx",
+			src: `package a
+
+import "context"
+
+func eff() string { return "e" }
+
+func F(vm string, ctx context.Context, b, c, d string) string {
+	_ = ctx
+	return vm + b + c + d
+}
+
+var _ = F(eff(), context.TODO(), "b", "c", "d")
+`,
+			reason: "evaluation order",
+		},
+		{
+			name: "ctx argument is an arbitrary call",
+			src: `package a
+
+import "context"
+
+func mkCtx() context.Context { return context.TODO() }
+
+func F(vm string, ctx context.Context, b, c, d string) string {
+	_ = ctx
+	return vm + b + c + d
+}
+
+var _ = F("v", mkCtx(), "b", "c", "d")
+`,
+			reason: "evaluation order",
+		},
+		{
 			name: "param reused on := left side",
 			src: `package a
 func F(cfg, b, c, d, e string) (string, error) {

--- a/structify/structify_test.go
+++ b/structify/structify_test.go
@@ -207,6 +207,40 @@ func TestSum(t *testing.T) {
 	mustContain(t, out["a/a_test.go"], "Sum(SumParams{A1: 1, A2: 2, A3: 3, A4: 4, A5: 5})")
 }
 
+func TestExternalTestPackageCallerGetsQualifier(t *testing.T) {
+	// package a_test is a DIFFERENT package: the params struct must be
+	// written as a.SumParams there, not bare SumParams.
+	dir, pkgs := loadModule(t, map[string]string{
+		"a/a.go": `package a
+
+type M struct{}
+
+func (M) Sum(a1, a2, a3, a4, a5 int) int { return a1 + a2 + a3 + a4 + a5 }
+`,
+		"a/a_ext_test.go": `package a_test
+
+import (
+	"testing"
+
+	"example.com/m/a"
+)
+
+func TestSum(t *testing.T) {
+	var m a.M
+	if m.Sum(1, 2, 3, 4, 5) != 15 {
+		t.Fatal("nope")
+	}
+}
+`,
+	})
+	res := plan(t, pkgs)
+	if len(res.Rewritten) != 1 {
+		t.Fatalf("rewritten=%d skipped=%+v", len(res.Rewritten), res.Skipped)
+	}
+	out := applyAll(t, dir, res)
+	mustContain(t, out["a/a_ext_test.go"], "m.Sum(a.SumParams{A1: 1, A2: 2, A3: 3, A4: 4, A5: 5})")
+}
+
 func TestNestedStructifiedCalls(t *testing.T) {
 	// outer's params are used as arguments to inner — the ident rewrites
 	// happen inside spans that the caller rewrite wraps with insertions.

--- a/structify/structify_test.go
+++ b/structify/structify_test.go
@@ -368,19 +368,19 @@ var _ = F(1, 2, 3, 4, 5)
 			reason: "generic",
 		},
 		{
-			name: "ctx not in leading position",
+			name: "multiple ctx params",
 			src: `package a
 
 import "context"
 
-func F(vm string, ctx context.Context, b, c, d string) string {
-	_ = ctx
-	return vm + b + c + d
+func F(ctx context.Context, b, c, d string, ctx2 context.Context) string {
+	_, _ = ctx, ctx2
+	return b + c + d
 }
 
-var _ = F("v", context.TODO(), "b", "c", "d")
+var _ = F(context.TODO(), "b", "c", "d", context.TODO())
 `,
-			reason: "not in leading position",
+			reason: "multiple context.Context",
 		},
 		{
 			name: "param reused on := left side",
@@ -462,6 +462,100 @@ var _ = G(1, 2, 3, 4, 5)
 	res := plan(t, pkgs)
 	if len(res.Rewritten) != 0 || len(res.Skipped) != 0 {
 		t.Fatalf("suppressed funcs were processed: rewritten=%d skipped=%d", len(res.Rewritten), len(res.Skipped))
+	}
+}
+
+func TestCtxHoistedToFront(t *testing.T) {
+	dir, pkgs := loadModule(t, map[string]string{
+		"a/a.go": `package a
+
+import "context"
+
+// dispatch runs one tool call.
+func dispatch(vm string, ctx context.Context, opts int, name string, argv []byte) string {
+	_ = ctx
+	return vm + name + string(argv) + string(rune(opts))
+}
+
+func kick(ctx context.Context) string {
+	return dispatch("vm", ctx, 7, "n", []byte("x"))
+}
+`,
+		"b/b.go": `package b
+
+import (
+	"context"
+
+	"example.com/m/a"
+)
+
+// ctx argument in the middle AND as the last argument.
+func Use() string {
+	return a.Dispatch2("vm", 7, "n", []byte("x"), context.Background())
+}
+`,
+		"a/a2.go": `package a
+
+import "context"
+
+func Dispatch2(vm string, opts int, name string, argv []byte, ctx context.Context) string {
+	_ = ctx
+	return vm + name
+}
+`,
+	})
+	res := plan(t, pkgs)
+	if len(res.Rewritten) != 2 {
+		t.Fatalf("rewritten=%d skipped=%+v", len(res.Rewritten), res.Skipped)
+	}
+	out := applyAll(t, dir, res)
+
+	a := out["a/a.go"]
+	mustContain(t, a, "func dispatch(ctx context.Context, arg dispatchParams) string {")
+	mustContain(t, a, `dispatch(ctx, dispatchParams{Vm: "vm", Opts: 7, Name: "n", Argv: []byte("x")})`)
+	if strings.Contains(a, "Ctx") {
+		t.Errorf("ctx leaked into the params struct:\n%s", a)
+	}
+	a2 := out["a/a2.go"]
+	mustContain(t, a2, "func Dispatch2(ctx context.Context, arg Dispatch2Params) string {")
+	b := out["b/b.go"]
+	mustContain(t, b, `a.Dispatch2(context.Background(), a.Dispatch2Params{Vm: "vm", Opts: 7, Name: "n", Argv: []byte("x")})`)
+}
+
+func TestCtxArgReferencingRewrittenParamSkips(t *testing.T) {
+	_, pkgs := loadModule(t, map[string]string{
+		"a/a.go": `package a
+
+import "context"
+
+func wrap(s string) context.Context { _ = s; return context.TODO() }
+
+func inner(vm string, ctx context.Context, b, c, d string) string {
+	_ = ctx
+	return vm + b + c + d
+}
+
+// outer is itself structified; its param "name" is renamed to arg.Name,
+// and it appears inside inner's ctx argument — the move would orphan it.
+func outer(name, e2, e3, e4, e5 string) string {
+	return inner("vm", wrap(name), e2, e3, e4) + e5
+}
+
+var _ = outer("n", "a", "b", "c", "d")
+`,
+	})
+	res := plan(t, pkgs)
+	var innerSkip *structify.Target
+	for _, s := range res.Skipped {
+		if s.Name == "inner" {
+			innerSkip = s
+		}
+	}
+	if innerSkip == nil {
+		t.Fatalf("inner not skipped; rewritten=%+v skipped=%+v", res.Rewritten, res.Skipped)
+	}
+	if !strings.Contains(innerSkip.SkipReason, "references a parameter being rewritten") {
+		t.Fatalf("reason = %q", innerSkip.SkipReason)
 	}
 }
 

--- a/structify/structify_test.go
+++ b/structify/structify_test.go
@@ -368,6 +368,21 @@ var _ = F(1, 2, 3, 4, 5)
 			reason: "generic",
 		},
 		{
+			name: "ctx not in leading position",
+			src: `package a
+
+import "context"
+
+func F(vm string, ctx context.Context, b, c, d string) string {
+	_ = ctx
+	return vm + b + c + d
+}
+
+var _ = F("v", context.TODO(), "b", "c", "d")
+`,
+			reason: "not in leading position",
+		},
+		{
 			name: "param reused on := left side",
 			src: `package a
 func F(cfg, b, c, d, e string) (string, error) {

--- a/structify/suppress.go
+++ b/structify/suppress.go
@@ -1,0 +1,67 @@
+package structify
+
+import (
+	"go/ast"
+	"go/token"
+	"os"
+	"strings"
+)
+
+// Suppression comments honored, in either spelling:
+//
+//	//lint:ignore structify <reason>        (line above the declaration)
+//	//lint:file-ignore structify <reason>   (whole file)
+//	// structify:ignore <reason>            (line above the declaration)
+//
+// The legacy analyzer name "funcparamlint" is accepted anywhere "structify"
+// is, so existing suppressions keep working after a swap.
+const analyzerName = "structify"
+
+const legacyName = "funcparamlint"
+
+type suppressions struct {
+	lines map[int]bool
+	file  bool
+}
+
+func parseSuppressions(fset *token.FileSet, f *ast.File) suppressions {
+	s := suppressions{lines: map[int]bool{}}
+	for _, group := range f.Comments {
+		for _, c := range group.List {
+			text := strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(c.Text, "//"), "/*"))
+			fields := strings.Fields(text)
+			if len(fields) < 2 {
+				continue
+			}
+			switch fields[0] {
+			case "lint:ignore":
+				if nameMatches(fields[1]) {
+					s.lines[fset.Position(c.End()).Line+1] = true
+				}
+			case "lint:file-ignore":
+				if nameMatches(fields[1]) {
+					s.file = true
+				}
+			case analyzerName + ":ignore":
+				s.lines[fset.Position(c.End()).Line+1] = true
+			}
+		}
+	}
+	return s
+}
+
+func nameMatches(list string) bool {
+	for _, name := range strings.Split(list, ",") {
+		name = strings.TrimSpace(name)
+		if name == analyzerName || name == legacyName {
+			return true
+		}
+	}
+	return false
+}
+
+func (s suppressions) ignored(fset *token.FileSet, pos token.Pos) bool {
+	return s.file || s.lines[fset.Position(pos).Line]
+}
+
+func readFile(name string) ([]byte, error) { return os.ReadFile(name) }


### PR DESCRIPTION
## Summary
New `structify` module: finds functions with too many input parameters (default >4, matching the classic funcparamlint rule), generates a `XxxParams` struct from the parameter names, rewrites the signature and body, and — the important part — **rewrites every caller across the loaded packages**, including test files. A leading `context.Context` stays positional.

Designed as the middle step of a codegen pipeline: **codegen → structify → fieldalign** (structs it generates get optimally packed by the next step).

## Safety model
A signature change is only safe when every reference is visible and rewritable. Functions are skipped with a reason when they:
- are variadic, generic, or have blank (`_`) params
- are referenced as function values
- satisfy an interface in the loaded set
- reuse a param on the left of `:=` (selector would be invalid there)
- have callers in generated files (regen would break the build) or callers that can't name the struct
- carry `//go:*`/`//export` directives or a suppression comment

Caller rewrites are zero-width insertions around existing argument expressions, so they compose with body rewrites happening inside those arguments — nested structified calls work in a single pass.

## Testing
- Golden rewrites: plain funcs, ctx handling, cross-package method callers, test-file callers, nested structified calls, shadowing, initialisms, name collisions, arg-name collision avoidance
- Every skip gate has a test
- Each rewritten test module is **reloaded and re-typechecked** — the strongest guarantee a signature-changing refactor can offer
- Real-world validation: ran against ditto-assistant/backend — 264 functions / 217 files rewritten, `go build ./...` clean, 28 conservative skips (18 interface methods)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `structify` CLI to report or automatically rewrite functions with more than the configured parameter limit into a single params-struct form, updating call sites accordingly.
  * Introduced a reusable library for planning and applying rewrites, plus analyzer support for function literals.
  * Added ignore comment support (including both modern and legacy suppression spellings), for file/line/function.
* **Bug Fixes**
  * Improved safety handling for methods, context parameters, generated code, and `_test.go`, with deterministic edit application.
* **Tests**
  * Expanded end-to-end rewrite/idempotency coverage and skip-reason assertions.
* **Chores**
  * Updated Go toolchain/version and related dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->